### PR TITLE
bodyに左右100padding適用　h1タグ用layout作成

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -6,4 +6,10 @@
   .btn {
     @apply bg-[#1D8EB9] border-indigo-700 px-4 py-2 rounded-md text-base text-white border hover:text-gray-900;
   }
+  .body {
+    @apply px-28;
+  }
+  .title {
+    @apply text-4xl;
+  }
 }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -32,7 +32,7 @@
     </div>
   </header>
   <!-- output the page content -->
-  <div class="p-4">
+  <div class="body">
     <slot />
   </div>
 


### PR DESCRIPTION
## Issue のリンク

-　https://github.com/KonishiTatsuki/qiita-builder/issues/15 

## やったこと(What,How)

- 左右のpaddingを112PXで適用
- h1タグ用のclass作成　クラス名：title　内容：text-4xl

## やらないこと

-　なし

## できるようになること（ユーザ目線）(Why,Who)

-　なし

## できなくなること（ユーザ目線）

-　なし

## 動作確認

-　なし

## タスク

-　なし

## エラー表示内容

-　なし

## その他

-　なし
