### PR TITLE
 🎨 記事投稿/編集画面のUIを作成

### DIFF
--- a/pages/articles/edit.vue
+++ b/pages/articles/edit.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="my-20">
+  <div class="my-20 text-right">
+    <div>
+        <button type="submit" class="btn mb-4">記事を削除</button>
+    </div>
     <div>
         <input type="text" class="border" style="width: 100%; height: 50px;" placeholder="タイトル">
     </div>
@@ -30,7 +33,7 @@
         </div>
       <div>
         <span class="mr-4">
-            <button type="submit" class="btn text-right">投稿する</button>
+            <button type="submit" class="btn">編集完了</button>
         </span>
         <span>
             <button type="submit" class="border py-2 px-2 rounded-md">下書き保存</button>

--- a/pages/articles/new.vue
+++ b/pages/articles/new.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="my-10">
+    <div>
+        <input type="text" class="border" style="width: 100%; height: 50px;" placeholder="タイトル">
+    </div>
+    <br>
+    <div>
+        <textarea placeholder="本文(マークエディタ)" class="border" style="width: 100%; height: 300px;"></textarea>
+    </div>
+    <!-- <div>
+        <h1 style="text-align: center;">Vue-multiselect</h1>
+        <multiselect
+          v-model="value"
+          :multiple="true"
+          :options="options"
+        ></multiselect>
+    </div> -->
+      <div>
+        <button type="submit" class="btn mt-5">投稿する</button>  
+      </div>
+  </div>
+
+</template>
+
+<script>
+// import Vue from 'vue'
+// import Multiselect from 'vue-multiselect'
+// Vue.component('multiselect', Multiselect)
+// export default {
+//   components: { Multiselect },
+//   data() {
+//     return {
+//       value: null,
+//       options: ['list', 'of', 'options'],
+//     }
+//   },
+// }
+</script>


### PR DESCRIPTION
## Issue のリンク

- https://github.com/KonishiTatsuki/qiita-builder/issues/5
- https://github.com/KonishiTatsuki/qiita-builder/issues/6

## やったこと(What,How)

- 記事投稿/編集画面のUI作成

## やらないこと

- VueMultiselectを使ったプルダウン(いいねの数を決める部分)/タグ入力欄の実装
- 本文をマークエディタで実装
- その他諸々のデザインは未確定です
- CRUD操作が必要な部分の実装

## できるようになること（ユーザ目線）(Why,Who)

-

## できなくなること（ユーザ目線）

-

## 動作確認

-
<img width="1375" alt="スクリーンショット 2023-05-19 16 30 31" src="https://github.com/KonishiTatsuki/qiita-builder/assets/114968506/96e3ed4b-6890-42b2-978e-b9e7c0025642">


## タスク

-

## エラー表示内容

-

## その他

-
