### PR TITLE
:sparkles: アドベント編集の画像保存期間を延長・アドベント編集へのリンクパス設定

### DIFF
--- a/pages/editAdvent/[id].vue
+++ b/pages/editAdvent/[id].vue
@@ -83,7 +83,7 @@ const editSubmit = async () => {
     if (!avatarerror) {
       const { data } = await client.storage
         .from("bannarImage")
-        .createSignedUrl(filePath, 600);
+        .createSignedUrl(filePath, 2592000);
       const imageUrl = data.signedUrl;
       create = {
         id: route.params.id,

--- a/pages/ownerPage.vue
+++ b/pages/ownerPage.vue
@@ -36,7 +36,11 @@
       </div>
     </div>
     <div class="flex mt-12 ml-2">
-      <div><button class="btn" @click="editAdvent">編集</button></div>
+      <div>
+        <NuxtLink :to="`/editAdvent/${choseEditAdvent}`"
+          ><button class="btn" @click="editAdvent">編集</button></NuxtLink
+        >
+      </div>
     </div>
   </div>
   <div>


### PR DESCRIPTION
## Issue のリンク

- https://github.com/KonishiTatsuki/qiita-builder/issues/18

## やったこと(What,How)

-　アドベント編集画面のバナー画像のurl期限を延長
-    管理者画面からアドベント編集へのリンクパスを設定

## やらないこと

-

## できるようになること（ユーザ目線）(Why,Who)

- バナー画像のurl期限が2592000秒になった
- 管理者画面から編集画面へ遷移できるようになった

## できなくなること（ユーザ目線）

-

## 動作確認

-

## タスク

-

## エラー表示内容

-

## その他

-
