### PR TITLE
ログイン：新規登録ボタン作成、新規：qiitta連携ボタン作成

### DIFF
--- a/middleware/login.global.ts
+++ b/middleware/login.global.ts
@@ -10,7 +10,7 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
     } else if (to.path === registerpath) {
       console.log("新規登録");
     } else {
-      // return navigateTo("/login");
+      return navigateTo("/login");
     }
   } else {
     const userId = user.value?.id;

--- a/middleware/login.global.ts
+++ b/middleware/login.global.ts
@@ -4,8 +4,13 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
 
   if (!user.value) {
     const path = "/login";
-    if (to.path !== path) {
-      return navigateTo("/login");
+    const registerpath = "/userRegister";
+    if (to.path === path) {
+      console.log("ログイン");
+    } else if (to.path === registerpath) {
+      console.log("新規登録");
+    } else {
+      // return navigateTo("/login");
     }
   } else {
     const userId = user.value?.id;

--- a/middleware/login.global.ts
+++ b/middleware/login.global.ts
@@ -4,13 +4,8 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
 
   if (!user.value) {
     const path = "/login";
-    const registerpath = "/userRegister";
-    if (to.path === path) {
-      console.log("ログイン");
-    } else if (to.path === registerpath) {
-      console.log("新規登録");
-    } else {
-      // return navigateTo("/login");
+    if (to.path !== path) {
+      return navigateTo("/login");
     }
   } else {
     const userId = user.value?.id;

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -57,9 +57,6 @@
               </div>
             </FormKit>
           </div>
-          <NuxtLink to="/userRegister"
-            ><button class="btn mb-2">新規会員登録</button></NuxtLink
-          >
         </div>
       </div>
     </div>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -57,6 +57,9 @@
               </div>
             </FormKit>
           </div>
+          <NuxtLink to="/userRegister"
+            ><button class="btn mb-2">新規会員登録</button></NuxtLink
+          >
         </div>
       </div>
     </div>

--- a/pages/userRegister.vue
+++ b/pages/userRegister.vue
@@ -1,259 +1,250 @@
 <template>
-  <div class="flex justify-center">
-    <div>
-      <FormKit
-        type="form"
-        @submit="submitHandler"
-        #default="{ value }"
-        id="register"
-        :actions="false"
-        incomplete-message=" "
-      >
-        <div class="h-1/5">
+  <FormKit
+    type="form"
+    @submit="submitHandler"
+    #default="{ value }"
+    id="register"
+    :actions="false"
+    incomplete-message=" "
+  >
+    <div class="h-1/5">
+      <div>
+        <div>
           <div>
-            <div>
+            <h1 class="title">新規登録</h1>
+            <div class="mb-2">
               <div>
-                <h1 class="title">新規登録</h1>
-                <div class="mb-2">
-                  <div>
-                    <FormKit
-                      :classes="{
-                        input: 'border border-black py-1 px-2 rounded-md',
-                        message: 'text-red-500',
-                      }"
-                      type="text"
-                      label=" ユーザ名"
-                      name="userName"
-                      validation="required|length:0,30|matches:/"
-                      autocomplete="off"
-                      :validation-messages="{
-                        required: 'ユーザ名を入力してください',
-                        length: '30文字以内で入力してください',
-                      }"
-                    />
-                  </div>
-                </div>
-                <div class="mb-2">
-                  <div>
-                    <FormKit
-                      :classes="{
-                        input: 'border border-black py-1 px-2 rounded-md',
-                        message: 'text-red-500',
-                      }"
-                      type="email"
-                      label=" メールアドレス"
-                      name="email"
-                      validation="required|matches:/^[A-Za-z0-9]{1}[A-Za-z0-9_.-]*@{1}[A-Za-z0-9_.-]+.[A-Za-z0-9]+$/|ends_with:rakus-partners.co.jp"
-                      autocomplete="off"
-                      :validation-messages="{
-                        required: 'メールアドレスを入力してください',
-                        matches: '正しいメールアドレスを入力してください',
-                        ends_with: 'ラクスのメールアドレスを入力してください',
-                      }"
-                    />
-                  </div>
-                </div>
-                <div class="mb-2">
-                  <div>
-                    <FormKit
-                      :classes="{
-                        input: 'border border-black py-1 px-2 rounded-md',
-                        message: 'text-red-500',
-                      }"
-                      type="password"
-                      label=" パスワード"
-                      name="password"
-                      validation="required|length:8,30|contains_numeric|contains_lowercase|contains_uppercase"
-                      autocomplete="off"
-                      :validation-messages="{
-                        required: 'パスワードを入力してください',
-                        length: '8文字以上30文字以内で入力してください',
-                        contains_numeric:
-                          '半角英小文字・大文字・数字をそれぞれ1種類以上含んでください',
-                        contains_lowercase:
-                          '半角英小文字・大文字・数字をそれぞれ1種類以上含んでください',
-                        contains_uppercase:
-                          '半角英小文字・大文字・数字をそれぞれ1種類以上含んでください',
-                      }"
-                    />
-                  </div>
-                </div>
-                <div class="mb-2">
-                  <div>
-                    <FormKit
-                      :classes="{
-                        input: 'border border-black py-1 px-2 rounded-md',
-                        message: 'text-red-500',
-                      }"
-                      type="password"
-                      label=" パスワード確認用"
-                      name="password_confirm"
-                      validation="required|confirm"
-                      autocomplete="off"
-                      :validation-messages="{
-                        required: 'パスワードを入力してください',
-                        confirm: 'パスワードが一致しません',
-                      }"
-                    />
-                  </div>
-                </div>
-              </div>
-              <div class="mb-2 flex">
                 <FormKit
                   :classes="{
                     input: 'border border-black py-1 px-2 rounded-md',
                     message: 'text-red-500',
                   }"
-                  type="select"
-                  label="サークル名"
-                  name="club"
-                  placeholder="サークル選択"
-                  validation="required"
-                  :options="club"
-                  :validation-messages="{
-                    required:
-                      'サークルを選択してください(該当するものがない場合はその他を選択)',
-                  }"
-                />
-                <FormKit
-                  :classes="{
-                    input: 'border border-black  py-1 px-2 rounded-md',
-                    message: 'text-red-500',
-                  }"
                   type="text"
-                  label="追加サークル"
-                  placeholder="その他"
-                  name="addClub"
+                  label=" ユーザ名"
+                  name="userName"
+                  validation="required|length:0,30|matches:/"
                   autocomplete="off"
+                  :validation-messages="{
+                    required: 'ユーザ名を入力してください',
+                    length: '30文字以内で入力してください',
+                  }"
                 />
               </div>
-              <div class="mb-2">
-                <div class="flex">
-                  <FormKit
-                    :classes="{
-                      wrapper: 'flex',
-                      options: 'flex ',
-                      option: 'pr-2',
-                      decorator: 'none',
-                      message: 'text-red-500',
-                    }"
-                    type="radio"
-                    label="職種"
-                    :options="occupation"
-                    name="occupation"
-                    validation="required"
-                    :validation-messages="{
-                      required: '職種を選択してください',
-                    }"
-                  />
-                </div>
-              </div>
-              <div class="mb-2">
+            </div>
+            <div class="mb-2">
+              <div>
                 <FormKit
                   :classes="{
+                    input: 'border border-black py-1 px-2 rounded-md',
                     message: 'text-red-500',
                   }"
-                  type="file"
-                  name="file"
-                  label="アイコン画像"
-                  accept=".png,.jpeg,.jpg"
-                  validation="required"
+                  type="email"
+                  label=" メールアドレス"
+                  name="email"
+                  validation="required|matches:/^[A-Za-z0-9]{1}[A-Za-z0-9_.-]*@{1}[A-Za-z0-9_.-]+.[A-Za-z0-9]+$/|ends_with:rakus-partners.co.jp"
+                  autocomplete="off"
                   :validation-messages="{
-                    required: '画像を選択してください',
+                    required: 'メールアドレスを入力してください',
+                    matches: '正しいメールアドレスを入力してください',
+                    ends_with: 'ラクスのメールアドレスを入力してください',
                   }"
                 />
               </div>
+            </div>
+            <div class="mb-2">
               <div>
-                <div>
-                  <FormKit
-                    :classes="{
-                      input: 'border border-black  py-1 px-2 rounded-md',
-                      message: 'text-red-500',
-                    }"
-                    type="textarea"
-                    name="detail"
-                    label="自己紹介"
-                    rows="10"
-                    cols="40"
-                    validation="required|length:0,255"
-                    :validation-messages="{
-                      required: '自己紹介を入力してください',
-                      length: '255文字以内で入力してください',
-                    }"
-                  />
-                </div>
+                <FormKit
+                  :classes="{
+                    input: 'border border-black py-1 px-2 rounded-md',
+                    message: 'text-red-500',
+                  }"
+                  type="password"
+                  label=" パスワード"
+                  name="password"
+                  validation="required|length:8,30|contains_numeric|contains_lowercase|contains_uppercase"
+                  autocomplete="off"
+                  :validation-messages="{
+                    required: 'パスワードを入力してください',
+                    length: '8文字以上30文字以内で入力してください',
+                    contains_numeric:
+                      '半角英小文字・大文字・数字をそれぞれ1種類以上含んでください',
+                    contains_lowercase:
+                      '半角英小文字・大文字・数字をそれぞれ1種類以上含んでください',
+                    contains_uppercase:
+                      '半角英小文字・大文字・数字をそれぞれ1種類以上含んでください',
+                  }"
+                />
+              </div>
+            </div>
+            <div class="mb-2">
+              <div>
+                <FormKit
+                  :classes="{
+                    input: 'border border-black py-1 px-2 rounded-md',
+                    message: 'text-red-500',
+                  }"
+                  type="password"
+                  label=" パスワード確認用"
+                  name="password_confirm"
+                  validation="required|confirm"
+                  autocomplete="off"
+                  :validation-messages="{
+                    required: 'パスワードを入力してください',
+                    confirm: 'パスワードが一致しません',
+                  }"
+                />
               </div>
             </div>
           </div>
-          <p>{{ errormesssage }}</p>
+          <div class="mb-2 flex">
+            <FormKit
+              :classes="{
+                input: 'border border-black py-1 px-2 rounded-md',
+                message: 'text-red-500',
+              }"
+              type="select"
+              label="サークル名"
+              name="club"
+              placeholder="サークル選択"
+              validation="required"
+              :options="club"
+              :validation-messages="{
+                required:
+                  'サークルを選択してください(該当するものがない場合はその他を選択)',
+              }"
+            />
+            <FormKit
+              :classes="{
+                input: 'border border-black  py-1 px-2 rounded-md',
+                message: 'text-red-500',
+              }"
+              type="text"
+              label="追加サークル"
+              placeholder="その他"
+              name="addClub"
+              autocomplete="off"
+            />
+          </div>
+          <div class="mb-2">
+            <div class="flex">
+              <FormKit
+                :classes="{
+                  wrapper: 'flex',
+                  options: 'flex ',
+                  option: 'pr-2',
+                  decorator: 'none',
+                  message: 'text-red-500',
+                }"
+                type="radio"
+                label="職種"
+                :options="occupation"
+                name="occupation"
+                validation="required"
+                :validation-messages="{
+                  required: '職種を選択してください',
+                }"
+              />
+            </div>
+          </div>
+          <div class="mb-2">
+            <FormKit
+              :classes="{
+                message: 'text-red-500',
+              }"
+              type="file"
+              name="file"
+              label="アイコン画像"
+              accept=".png,.jpeg,.jpg"
+              validation="required"
+              :validation-messages="{
+                required: '画像を選択してください',
+              }"
+            />
+          </div>
+          <div>
+            <div>
+              <FormKit
+                :classes="{
+                  input: 'border border-black  py-1 px-2 rounded-md',
+                  message: 'text-red-500',
+                }"
+                type="textarea"
+                name="detail"
+                label="自己紹介"
+                rows="10"
+                cols="40"
+                validation="required|length:0,255"
+                :validation-messages="{
+                  required: '自己紹介を入力してください',
+                  length: '255文字以内で入力してください',
+                }"
+              />
+            </div>
+          </div>
         </div>
-      </FormKit>
-      <div class="flex mb-4 justify-center mt-4">
-        <button class="btn" @click="submitRegister">登録する</button>
-        <button class="btn" @click="connectQitta">
-          登録してQiitaを連携する
-        </button>
+        <div></div>
+      </div>
+
+      <div class="flex mb-4">
+        <button class="btn">登録する</button>
+        <p>{{ errormesssage }}</p>
       </div>
     </div>
-  </div>
+
+    <!-- <pre wrap>{{ value }}</pre> -->
+  </FormKit>
 </template>
 
 <script setup>
-import { submitForm } from "@formkit/core";
 const errormesssage = ref("");
 const club = [{ label: "その他(右フォームに記入)", value: "others" }];
 const occupation = [];
 const { data: clubb } = await useFetch("/api/club/get");
 const { data: occupationn } = await useFetch("/api/occupation/get");
-const router = useRouter();
-const succes = ref();
+
 occupationn.value.map((c) => {
   occupation.push({ label: c.occupationName, value: c.id });
 });
 clubb.value.map((c) => {
   club.push({ label: c.clubName, value: c.id });
 });
-const client = useSupabaseClient();
 
 //登録する押下
-const submitRegister = async () => {
-  submitForm("register");
-  if (succes) {
-    router.push("/");
-  }
-};
-
-//qiitta連携
-const connectQitta = () => {
-  submitForm("register");
-  if (succes) {
-    router.push("/qiitaCoordination");
-  }
-};
-
-//supabaseへのデータ保存
 const submitHandler = async (credentials) => {
   console.log(credentials);
-  let clubId = credentials.club;
+  const client = useSupabaseClient();
+
+  //追加クラブがないときはブルダウンのクラブをpostするための変数
+  let clubid = credentials.club;
+
+  // 追加クラブの登録と取得
   if (credentials.addClub) {
     //追加クラブをdisplay:falseで登録
-    await client.from("club").insert({
+    const { error: cluberror } = await client.from("club").insert({
       clubName: credentials.addClub,
     });
+    const { data } = await client
+      .from("club")
+      .select("id")
+      .eq("clubName", credentials.addClub);
 
-    await client.from("club").select("id").eq("clubName", body.addClub);
-    clubId = data[0].id;
+    clubid = data[0].id;
   }
+
   //アイコン画像を保存
+  console.log(credentials.file[0].file);
   const file = credentials.file[0].file; // 選択された画像を取得
   const filePath = `${credentials.file[0].name}`; // 画像の保存先のpathを指定
   const { error: avatarerror } = await client.storage
     .from("avatars")
     .upload(filePath, file);
+  // console.log("avatarerror", avatarerror);
   // 画像のURLを取得
   if (!avatarerror) {
     const { data } = client.storage.from("avatars").getPublicUrl(filePath);
     const imageUrl = data.publicUrl;
+    // console.log("url", imageUrl);
+
     //新規会員登録
     // authに登録;
     const { error } = await client.auth.signUp({
@@ -263,16 +254,45 @@ const submitHandler = async (credentials) => {
         data: {
           username: credentials.userName,
           detail: credentials.detail,
-          clubid: clubId,
+          clubid: clubid,
           email: credentials.email,
           occupation: credentials.occupation,
           image: imageUrl,
         },
       },
     });
+    if (!error) {
+      //ログインする
+      const { data } = await client.auth.signInWithPassword({
+        email: credentials.email,
+        password: credentials.password,
+      });
+      if (data.session) {
+        location.href = "/";
+      }
+    } else {
+      errormesssage.value = "既に登録されているメールアドレスです";
+    }
+    console.log("error", error);
   } else {
-    errormesssage.value = "画像が重複しています";
-    succes.value = true;
+    errormesssage.value = "アバター画像名が既に重複しています。";
   }
+
+  //authに登録
+  // const { data } = useFetch("/api/user/register", {
+  //   method: "POST",
+  //   body: credentials,
+  // });
+
+  console.log("完了");
 };
 </script>
+
+<!-- await client.auth.signUp({
+  email: credentials.email,
+    password: credentials.password,
+   });
+   await client.auth.signInWithPassword({
+    email: "madoka.kato@rakus-partners.co.jp",
+     password: "Maka7816",
+   }); -->

--- a/pages/userRegister.vue
+++ b/pages/userRegister.vue
@@ -1,250 +1,259 @@
 <template>
-  <FormKit
-    type="form"
-    @submit="submitHandler"
-    #default="{ value }"
-    id="register"
-    :actions="false"
-    incomplete-message=" "
-  >
-    <div class="h-1/5">
-      <div>
-        <div>
+  <div class="flex justify-center">
+    <div>
+      <FormKit
+        type="form"
+        @submit="submitHandler"
+        #default="{ value }"
+        id="register"
+        :actions="false"
+        incomplete-message=" "
+      >
+        <div class="h-1/5">
           <div>
-            <h1 class="title">新規登録</h1>
-            <div class="mb-2">
+            <div>
               <div>
+                <h1 class="title">新規登録</h1>
+                <div class="mb-2">
+                  <div>
+                    <FormKit
+                      :classes="{
+                        input: 'border border-black py-1 px-2 rounded-md',
+                        message: 'text-red-500',
+                      }"
+                      type="text"
+                      label=" ユーザ名"
+                      name="userName"
+                      validation="required|length:0,30|matches:/"
+                      autocomplete="off"
+                      :validation-messages="{
+                        required: 'ユーザ名を入力してください',
+                        length: '30文字以内で入力してください',
+                      }"
+                    />
+                  </div>
+                </div>
+                <div class="mb-2">
+                  <div>
+                    <FormKit
+                      :classes="{
+                        input: 'border border-black py-1 px-2 rounded-md',
+                        message: 'text-red-500',
+                      }"
+                      type="email"
+                      label=" メールアドレス"
+                      name="email"
+                      validation="required|matches:/^[A-Za-z0-9]{1}[A-Za-z0-9_.-]*@{1}[A-Za-z0-9_.-]+.[A-Za-z0-9]+$/|ends_with:rakus-partners.co.jp"
+                      autocomplete="off"
+                      :validation-messages="{
+                        required: 'メールアドレスを入力してください',
+                        matches: '正しいメールアドレスを入力してください',
+                        ends_with: 'ラクスのメールアドレスを入力してください',
+                      }"
+                    />
+                  </div>
+                </div>
+                <div class="mb-2">
+                  <div>
+                    <FormKit
+                      :classes="{
+                        input: 'border border-black py-1 px-2 rounded-md',
+                        message: 'text-red-500',
+                      }"
+                      type="password"
+                      label=" パスワード"
+                      name="password"
+                      validation="required|length:8,30|contains_numeric|contains_lowercase|contains_uppercase"
+                      autocomplete="off"
+                      :validation-messages="{
+                        required: 'パスワードを入力してください',
+                        length: '8文字以上30文字以内で入力してください',
+                        contains_numeric:
+                          '半角英小文字・大文字・数字をそれぞれ1種類以上含んでください',
+                        contains_lowercase:
+                          '半角英小文字・大文字・数字をそれぞれ1種類以上含んでください',
+                        contains_uppercase:
+                          '半角英小文字・大文字・数字をそれぞれ1種類以上含んでください',
+                      }"
+                    />
+                  </div>
+                </div>
+                <div class="mb-2">
+                  <div>
+                    <FormKit
+                      :classes="{
+                        input: 'border border-black py-1 px-2 rounded-md',
+                        message: 'text-red-500',
+                      }"
+                      type="password"
+                      label=" パスワード確認用"
+                      name="password_confirm"
+                      validation="required|confirm"
+                      autocomplete="off"
+                      :validation-messages="{
+                        required: 'パスワードを入力してください',
+                        confirm: 'パスワードが一致しません',
+                      }"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div class="mb-2 flex">
                 <FormKit
                   :classes="{
                     input: 'border border-black py-1 px-2 rounded-md',
+                    message: 'text-red-500',
+                  }"
+                  type="select"
+                  label="サークル名"
+                  name="club"
+                  placeholder="サークル選択"
+                  validation="required"
+                  :options="club"
+                  :validation-messages="{
+                    required:
+                      'サークルを選択してください(該当するものがない場合はその他を選択)',
+                  }"
+                />
+                <FormKit
+                  :classes="{
+                    input: 'border border-black  py-1 px-2 rounded-md',
                     message: 'text-red-500',
                   }"
                   type="text"
-                  label=" ユーザ名"
-                  name="userName"
-                  validation="required|length:0,30|matches:/"
+                  label="追加サークル"
+                  placeholder="その他"
+                  name="addClub"
                   autocomplete="off"
-                  :validation-messages="{
-                    required: 'ユーザ名を入力してください',
-                    length: '30文字以内で入力してください',
-                  }"
                 />
               </div>
-            </div>
-            <div class="mb-2">
-              <div>
+              <div class="mb-2">
+                <div class="flex">
+                  <FormKit
+                    :classes="{
+                      wrapper: 'flex',
+                      options: 'flex ',
+                      option: 'pr-2',
+                      decorator: 'none',
+                      message: 'text-red-500',
+                    }"
+                    type="radio"
+                    label="職種"
+                    :options="occupation"
+                    name="occupation"
+                    validation="required"
+                    :validation-messages="{
+                      required: '職種を選択してください',
+                    }"
+                  />
+                </div>
+              </div>
+              <div class="mb-2">
                 <FormKit
                   :classes="{
-                    input: 'border border-black py-1 px-2 rounded-md',
                     message: 'text-red-500',
                   }"
-                  type="email"
-                  label=" メールアドレス"
-                  name="email"
-                  validation="required|matches:/^[A-Za-z0-9]{1}[A-Za-z0-9_.-]*@{1}[A-Za-z0-9_.-]+.[A-Za-z0-9]+$/|ends_with:rakus-partners.co.jp"
-                  autocomplete="off"
+                  type="file"
+                  name="file"
+                  label="アイコン画像"
+                  accept=".png,.jpeg,.jpg"
+                  validation="required"
                   :validation-messages="{
-                    required: 'メールアドレスを入力してください',
-                    matches: '正しいメールアドレスを入力してください',
-                    ends_with: 'ラクスのメールアドレスを入力してください',
+                    required: '画像を選択してください',
                   }"
                 />
               </div>
-            </div>
-            <div class="mb-2">
               <div>
-                <FormKit
-                  :classes="{
-                    input: 'border border-black py-1 px-2 rounded-md',
-                    message: 'text-red-500',
-                  }"
-                  type="password"
-                  label=" パスワード"
-                  name="password"
-                  validation="required|length:8,30|contains_numeric|contains_lowercase|contains_uppercase"
-                  autocomplete="off"
-                  :validation-messages="{
-                    required: 'パスワードを入力してください',
-                    length: '8文字以上30文字以内で入力してください',
-                    contains_numeric:
-                      '半角英小文字・大文字・数字をそれぞれ1種類以上含んでください',
-                    contains_lowercase:
-                      '半角英小文字・大文字・数字をそれぞれ1種類以上含んでください',
-                    contains_uppercase:
-                      '半角英小文字・大文字・数字をそれぞれ1種類以上含んでください',
-                  }"
-                />
-              </div>
-            </div>
-            <div class="mb-2">
-              <div>
-                <FormKit
-                  :classes="{
-                    input: 'border border-black py-1 px-2 rounded-md',
-                    message: 'text-red-500',
-                  }"
-                  type="password"
-                  label=" パスワード確認用"
-                  name="password_confirm"
-                  validation="required|confirm"
-                  autocomplete="off"
-                  :validation-messages="{
-                    required: 'パスワードを入力してください',
-                    confirm: 'パスワードが一致しません',
-                  }"
-                />
+                <div>
+                  <FormKit
+                    :classes="{
+                      input: 'border border-black  py-1 px-2 rounded-md',
+                      message: 'text-red-500',
+                    }"
+                    type="textarea"
+                    name="detail"
+                    label="自己紹介"
+                    rows="10"
+                    cols="40"
+                    validation="required|length:0,255"
+                    :validation-messages="{
+                      required: '自己紹介を入力してください',
+                      length: '255文字以内で入力してください',
+                    }"
+                  />
+                </div>
               </div>
             </div>
           </div>
-          <div class="mb-2 flex">
-            <FormKit
-              :classes="{
-                input: 'border border-black py-1 px-2 rounded-md',
-                message: 'text-red-500',
-              }"
-              type="select"
-              label="サークル名"
-              name="club"
-              placeholder="サークル選択"
-              validation="required"
-              :options="club"
-              :validation-messages="{
-                required:
-                  'サークルを選択してください(該当するものがない場合はその他を選択)',
-              }"
-            />
-            <FormKit
-              :classes="{
-                input: 'border border-black  py-1 px-2 rounded-md',
-                message: 'text-red-500',
-              }"
-              type="text"
-              label="追加サークル"
-              placeholder="その他"
-              name="addClub"
-              autocomplete="off"
-            />
-          </div>
-          <div class="mb-2">
-            <div class="flex">
-              <FormKit
-                :classes="{
-                  wrapper: 'flex',
-                  options: 'flex ',
-                  option: 'pr-2',
-                  decorator: 'none',
-                  message: 'text-red-500',
-                }"
-                type="radio"
-                label="職種"
-                :options="occupation"
-                name="occupation"
-                validation="required"
-                :validation-messages="{
-                  required: '職種を選択してください',
-                }"
-              />
-            </div>
-          </div>
-          <div class="mb-2">
-            <FormKit
-              :classes="{
-                message: 'text-red-500',
-              }"
-              type="file"
-              name="file"
-              label="アイコン画像"
-              accept=".png,.jpeg,.jpg"
-              validation="required"
-              :validation-messages="{
-                required: '画像を選択してください',
-              }"
-            />
-          </div>
-          <div>
-            <div>
-              <FormKit
-                :classes="{
-                  input: 'border border-black  py-1 px-2 rounded-md',
-                  message: 'text-red-500',
-                }"
-                type="textarea"
-                name="detail"
-                label="自己紹介"
-                rows="10"
-                cols="40"
-                validation="required|length:0,255"
-                :validation-messages="{
-                  required: '自己紹介を入力してください',
-                  length: '255文字以内で入力してください',
-                }"
-              />
-            </div>
-          </div>
+          <p>{{ errormesssage }}</p>
         </div>
-        <div></div>
-      </div>
-
-      <div class="flex mb-4">
-        <button class="btn">登録する</button>
-        <p>{{ errormesssage }}</p>
+      </FormKit>
+      <div class="flex mb-4 justify-center mt-4">
+        <button class="btn" @click="submitRegister">登録する</button>
+        <button class="btn" @click="connectQitta">
+          登録してQiitaを連携する
+        </button>
       </div>
     </div>
-
-    <!-- <pre wrap>{{ value }}</pre> -->
-  </FormKit>
+  </div>
 </template>
 
 <script setup>
+import { submitForm } from "@formkit/core";
 const errormesssage = ref("");
 const club = [{ label: "その他(右フォームに記入)", value: "others" }];
 const occupation = [];
 const { data: clubb } = await useFetch("/api/club/get");
 const { data: occupationn } = await useFetch("/api/occupation/get");
-
+const router = useRouter();
+const succes = ref();
 occupationn.value.map((c) => {
   occupation.push({ label: c.occupationName, value: c.id });
 });
 clubb.value.map((c) => {
   club.push({ label: c.clubName, value: c.id });
 });
+const client = useSupabaseClient();
 
 //登録する押下
+const submitRegister = async () => {
+  submitForm("register");
+  if (succes) {
+    router.push("/");
+  }
+};
+
+//qiitta連携
+const connectQitta = () => {
+  submitForm("register");
+  if (succes) {
+    router.push("/qiitaCoordination");
+  }
+};
+
+//supabaseへのデータ保存
 const submitHandler = async (credentials) => {
   console.log(credentials);
-  const client = useSupabaseClient();
-
-  //追加クラブがないときはブルダウンのクラブをpostするための変数
-  let clubid = credentials.club;
-
-  // 追加クラブの登録と取得
+  let clubId = credentials.club;
   if (credentials.addClub) {
     //追加クラブをdisplay:falseで登録
-    const { error: cluberror } = await client.from("club").insert({
+    await client.from("club").insert({
       clubName: credentials.addClub,
     });
-    const { data } = await client
-      .from("club")
-      .select("id")
-      .eq("clubName", credentials.addClub);
 
-    clubid = data[0].id;
+    await client.from("club").select("id").eq("clubName", body.addClub);
+    clubId = data[0].id;
   }
-
   //アイコン画像を保存
-  console.log(credentials.file[0].file);
   const file = credentials.file[0].file; // 選択された画像を取得
   const filePath = `${credentials.file[0].name}`; // 画像の保存先のpathを指定
   const { error: avatarerror } = await client.storage
     .from("avatars")
     .upload(filePath, file);
-  // console.log("avatarerror", avatarerror);
   // 画像のURLを取得
   if (!avatarerror) {
     const { data } = client.storage.from("avatars").getPublicUrl(filePath);
     const imageUrl = data.publicUrl;
-    // console.log("url", imageUrl);
-
     //新規会員登録
     // authに登録;
     const { error } = await client.auth.signUp({
@@ -254,45 +263,16 @@ const submitHandler = async (credentials) => {
         data: {
           username: credentials.userName,
           detail: credentials.detail,
-          clubid: clubid,
+          clubid: clubId,
           email: credentials.email,
           occupation: credentials.occupation,
           image: imageUrl,
         },
       },
     });
-    if (!error) {
-      //ログインする
-      const { data } = await client.auth.signInWithPassword({
-        email: credentials.email,
-        password: credentials.password,
-      });
-      if (data.session) {
-        location.href = "/";
-      }
-    } else {
-      errormesssage.value = "既に登録されているメールアドレスです";
-    }
-    console.log("error", error);
   } else {
-    errormesssage.value = "アバター画像名が既に重複しています。";
+    errormesssage.value = "画像が重複しています";
+    succes.value = true;
   }
-
-  //authに登録
-  // const { data } = useFetch("/api/user/register", {
-  //   method: "POST",
-  //   body: credentials,
-  // });
-
-  console.log("完了");
 };
 </script>
-
-<!-- await client.auth.signUp({
-  email: credentials.email,
-    password: credentials.password,
-   });
-   await client.auth.signInWithPassword({
-    email: "madoka.kato@rakus-partners.co.jp",
-     password: "Maka7816",
-   }); -->


### PR DESCRIPTION
## Issue のリンク

-  https://github.com/KonishiTatsuki/qiita-builder/issues/49

## やったこと(What,How)

- 未ログイン時に新規登録ページに遷移できるようmiddlewareを変更
- 新規登録画面にqiitta連携へ進むボタンを作成

## やらないこと

-

## できるようになること（ユーザ目線）(Why,Who)

-

## できなくなること（ユーザ目線）

-

## 動作確認

-

## タスク

-

## エラー表示内容

- 新規登録後、ログインするが取得が間に合わずログイン画面に戻ってしまう。

## その他

-
