### PR TITLE
:sparkles: qiitaTokenがnullの場合のエラーを解消

### DIFF
--- a/pages/userEdit/[id].vue
+++ b/pages/userEdit/[id].vue
@@ -178,7 +178,7 @@
     </div>
   </div>
   <div class="border border-black m-4 p-3">
-    QiitaユーザID:{{ data[0].qiitaToken }}
+    QiitaユーザID:{{ data[0].qiitaToken && data[0].qiitaToken }}
     <NuxtLink to="/qiitaCoordination">
       <button class="btn">Qiitaと連携する</button></NuxtLink
     >
@@ -186,14 +186,21 @@
 </template>
 
 <script setup>
-const editbool = ref(false);
-const iconeditbool = ref(false);
-
 const occupation = [];
 const route = useRoute();
 const router = useRouter();
 const club = [];
 const client = useSupabaseClient();
+//profile取得
+const { data } = useFetch("/api/user/get", {
+  method: "POST",
+  body: route.params.id,
+});
+console.log(data[0]);
+
+const editbool = ref(false);
+const iconeditbool = ref(false);
+
 const { data: clubb } = await useFetch("/api/club/get");
 const { data: occupationn } = await useFetch("/api/occupation/get");
 
@@ -247,10 +254,4 @@ const post = async (credentials) => {
 const edit = () => {
   editbool.value = !editbool.value;
 };
-
-//profile取得
-const { data } = useFetch("/api/user/get", {
-  method: "POST",
-  body: route.params.id,
-});
 </script>


### PR DESCRIPTION
## Issue のリンク

- https://github.com/KonishiTatsuki/qiita-builder/issues/71

## やったこと(What,How)

- ユーザ編集画面へ遷移した時にqiitaIDがない場合の時のエラーを解消

## やらないこと

-

## できるようになること（ユーザ目線）(Why,Who)

-

## できなくなること（ユーザ目線）

-

## 動作確認

-

## タスク

-

## エラー表示内容

-

## その他

-
