### PR TITLE
:+1: ログイン/パスワード再設定メール送信/パスワード再設定機能修正

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,7 +1,7 @@
 <template>
-  <header class="text-white bg-[#1D8EB9] body-font max-w-full mx-auto">
+  <header class="text-white bg-[#1D8EB9] body-font max-w-full mx-auto h-[68px] flex items-center">
     <div
-      class="container mx-auto flex flex-wrap p-5 flex-col md:flex-row items-center relative"
+      class="container mx-auto flex flex-wrap flex-col md:flex-row items-center"
     >
       <NuxtLink
         to="/"
@@ -37,8 +37,8 @@
     <slot />
   </div>
 
-  <footer class="bg-[#1D8EB9] py-4 mt-14">
-    <div class="container mx-auto px-4">
+  <footer class="bg-[#1D8EB9] h-[56px] mt-[44px] flex items-center">
+    <div class="container mx-auto ">
       <p class="text-center text-white">&copy; 2023 Qiita builder.</p>
     </div>
   </footer>
@@ -51,6 +51,6 @@ const client = useSupabaseClient();
 const logout = async () => {
   const { error } = await client.auth.signOut();
   console.log("ログアウト", error);
-  router.go();
+  router.push("/login");
 };
 </script>

--- a/layouts/login.vue
+++ b/layouts/login.vue
@@ -3,7 +3,12 @@
     <div
       class="container mx-auto flex flex-wrap p-5 flex-col md:flex-row items-center"
     >
-      <span class="ml-3 text-xl text-white">Qiita Builder</span>
+      <NuxtLink
+        to="/"
+        class="flex title-font font-medium items-center text-gray-900 md:mb-0"
+      >
+        <span class="ml-3 text-xl text-white">Qiita Builder</span>
+      </NuxtLink>
     </div>
   </header>
   <!-- output the page content -->

--- a/middleware/login.global.ts
+++ b/middleware/login.global.ts
@@ -20,9 +20,6 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
     }
   } else {
     const userId = user.value?.id;
-    // if (to.path === "/passwordReset") {
-    //   return navigateTo("/");
-    // }
     if (to.path === "/ownerPage") {
       //ログインユーザのauthority取得
       const { data: authority } = await client

--- a/middleware/login.global.ts
+++ b/middleware/login.global.ts
@@ -5,15 +5,24 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
   if (!user.value) {
     const path = "/login";
     const registerpath = "/userRegister";
+    const passwordForget = "/passwordForget";
+    const passwordReset = "/passwordReset#error=unauthorized_client&error_code=401&error_description=Email+link+is+invalid+or+has+expired";
     if (to.path === path) {
       console.log("ログイン");
-    } else if (to.path === registerpath) {
-      console.log("新規登録");
+    } else if (
+      to.path === registerpath ||
+      to.path === passwordForget ||
+      to.path === passwordReset
+    ) {
+      console.log("ログイン前でも遷移可能ページ");
     } else {
       return navigateTo("/login");
     }
   } else {
     const userId = user.value?.id;
+    // if (to.path === "/passwordReset") {
+    //   return navigateTo("/");
+    // }
     if (to.path === "/ownerPage") {
       //ログインユーザのauthority取得
       const { data: authority } = await client

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -1,66 +1,67 @@
 <template>
-  <div class="flex main">
-    <div class="flex-auto my-auto">
+  <div class="flex main justify-center">
+    <div class="my-auto text-center">
+      <h1 class="title">ログイン</h1>
       <div class="flex justify-center">
-        <div class="text-center">
-          <h1 class="title">ログイン</h1>
-          <div class="flex justify-center">
+        <FormKit
+          type="form"
+          @submit="submit"
+          :actions="false"
+          incomplete-message=" "
+        >
+          <div class="mb-2 text-center">
             <FormKit
-              type="form"
-              @submit="submit"
-              :actions="false"
-              incomplete-message=" "
-            >
-              <div class="mb-2 text-center">
-                <FormKit
-                  :classes="{
-                    input: 'border border-black py-1 px-2 rounded-md',
-                    message: 'text-red-500',
-                  }"
-                  type="email"
-                  label=" メールアドレス"
-                  name="email"
-                  validation="required|matches:/^[A-Za-z0-9]{1}[A-Za-z0-9_.-]*@{1}[A-Za-z0-9_.-]+.[A-Za-z0-9]+$/|ends_with:rakus-partners.co.jp"
-                  autocomplete="off"
-                  :validation-messages="{
-                    required: 'メールアドレスを入力してください',
-                    matches: '正しいメールアドレスを入力してください',
-                    ends_with: 'ラクスのメールアドレスを入力してください',
-                  }"
-                />
-              </div>
-              <div class="mb-5 text-center">
-                <FormKit
-                  :classes="{
-                    input: 'border border-black py-1 px-2 rounded-md',
-                    message: 'text-red-500',
-                  }"
-                  type="password"
-                  label=" パスワード"
-                  name="password"
-                  validation="required|length:8,30|contains_numeric|contains_lowercase|contains_uppercase"
-                  autocomplete="off"
-                  :validation-messages="{
-                    required: 'パスワードを入力してください',
-                    length: '8文字以上30文字以内で入力してください',
-                    contains_numeric:
-                      '半角英小文字・大文字・数字をそれぞれ1種類以上含んでください',
-                    contains_lowercase:
-                      '半角英小文字・大文字・数字をそれぞれ1種類以上含んでください',
-                    contains_uppercase:
-                      '半角英小文字・大文字・数字をそれぞれ1種類以上含んでください',
-                  }"
-                />
-              </div>
-              <div class="flex mb-4 justify-center">
-                <button class="btn">ログイン</button>
-              </div>
-            </FormKit>
+              :classes="{
+                input: 'border border-black py-1 px-2 rounded-md',
+                message: 'text-red-500',
+              }"
+              type="email"
+              label=" メールアドレス"
+              name="email"
+              validation="required|matches:/^[A-Za-z0-9]{1}[A-Za-z0-9_.-]*@{1}[A-Za-z0-9_.-]+.[A-Za-z0-9]+$/|ends_with:rakus-partners.co.jp"
+              autocomplete="off"
+              :validation-messages="{
+                required: 'メールアドレスを入力してください',
+                matches: '正しいメールアドレスを入力してください',
+                ends_with: 'ラクスのメールアドレスを入力してください',
+              }"
+            />
           </div>
-          <NuxtLink to="/userRegister"
-            ><button class="btn mb-2">新規会員登録</button></NuxtLink
-          >
-        </div>
+          <div class="mb-5 text-center">
+            <FormKit
+              :classes="{
+                input: 'border border-black py-1 px-2 rounded-md',
+                message: 'text-red-500',
+              }"
+              type="password"
+              label=" パスワード"
+              name="password"
+              validation="required|length:8,30|contains_numeric|contains_lowercase|contains_uppercase"
+              autocomplete="off"
+              :validation-messages="{
+                required: 'パスワードを入力してください',
+                length: '8文字以上30文字以内で入力してください',
+                contains_numeric:
+                  '半角英小文字・大文字・数字をそれぞれ1種類以上含んでください',
+                contains_lowercase:
+                  '半角英小文字・大文字・数字をそれぞれ1種類以上含んでください',
+                contains_uppercase:
+                  '半角英小文字・大文字・数字をそれぞれ1種類以上含んでください',
+              }"
+            />
+          </div>
+          <div class="flex justify-center">
+            <NuxtLink to="/userRegister"
+              ><button class="btn mb-2 mr-10">新規登録</button></NuxtLink
+            >
+            <div class="flex mb-4 justify-center">
+              <button class="btn">ログイン</button>
+            </div>
+          </div>
+          <NuxtLink to="/passwordForget"
+            ><div>※パスワードを忘れた場合</div>
+          </NuxtLink>
+        </FormKit>
       </div>
     </div>
   </div>
@@ -86,6 +87,6 @@ const submit = async (submit: { email: string; password: string }) => {
 
 <style scoped>
 .main {
-  min-height: calc(100vh - 168px);
+  min-height: calc(100vh - 124px);
 }
 </style>

--- a/pages/passwordForget.vue
+++ b/pages/passwordForget.vue
@@ -33,6 +33,9 @@
                 <button class="btn">送信</button>
               </div>
               <p>上記メールアドレスに再設定用のURLを送付します。</p>
+              <!-- <p v-if="success" class="text-red-500">{{ success }}</p>
+              <p v-else-if="errors" class="text-red-500">{{ errors }}</p>
+              <p v-else>上記メールアドレスに再設定用のURLを送付します。</p> -->
             </FormKit>
           </div>
         </div>
@@ -46,11 +49,28 @@ const router = useRouter();
 const supabase = useSupabaseClient();
 
 const email = ref("");
+const errors = ref("");
+const success = ref("");
 
 const submit = async (submit: { email: string }) => {
-  await supabase.auth.resetPasswordForEmail(submit.email, {
-    redirectTo: "http://localhost:3000/passwordReset",
-  });
+  const { data, error } = await supabase.auth.resetPasswordForEmail(
+    submit.email,
+    {
+      redirectTo: "http://localhost:3000/passwordReset",
+    }
+  );
+  console.log("data",data)
+  // console.log(data);
+  // if (data !== null) {
+  //   console.log(Object.keys(data).length);
+  //   console.log("error", error);
+  // }
+  // // if (error === null) {
+  // //   console.log("error", error);
+  // //   errors.value = "メールアドレスが登録されていません。";
+  // // } else{
+  // //   success.value = "メールを送信しました。";
+  // // }
 };
 </script>
 

--- a/pages/passwordReset.vue
+++ b/pages/passwordReset.vue
@@ -41,25 +41,20 @@
                     message: 'text-red-500',
                   }"
                   type="password"
-                  label="確認用パスワード"
-                  name="confirmPassword"
-                  validation="required|length:8,30|contains_numeric|contains_lowercase|contains_uppercase"
+                  label=" パスワード確認用"
+                  name="password_confirm"
+                  validation="required|confirm"
                   autocomplete="off"
                   :validation-messages="{
                     required: 'パスワードを入力してください',
-                    length: '8文字以上30文字以内で入力してください',
-                    contains_numeric:
-                      '半角英小文字・大文字・数字をそれぞれ1種類以上含んでください',
-                    contains_lowercase:
-                      '半角英小文字・大文字・数字をそれぞれ1種類以上含んでください',
-                    contains_uppercase:
-                      '半角英小文字・大文字・数字をそれぞれ1種類以上含んでください',
+                    confirm: 'パスワードが一致しません',
                   }"
                 />
               </div>
               <div class="flex mb-4 justify-center">
                 <button class="btn">登録</button>
               </div>
+              <p>{{ success }}</p>
             </FormKit>
           </div>
         </div>
@@ -75,13 +70,13 @@ const supabase = useSupabaseClient();
 
 const email = ref("");
 const password = ref("");
+const success = ref("");
 
 const submit = async (submit: { password: string }) => {
   const { data, error } = await supabase.auth.updateUser({
     password: submit.password,
   });
-  console.log("error", error);
-  console.log(data);
+  success.value = "パスワードを再設定しました。";
 };
 </script>
 

--- a/pages/passwordReset.vue
+++ b/pages/passwordReset.vue
@@ -5,11 +5,17 @@
         <div class="text-center">
           <h1 class="title">パスワード再設定</h1>
           <div class="flex justify-center">
-            <FormKit type="form" @submit="submit" submit-label="登録">
+            <FormKit
+              type="form"
+              @submit="submit"
+              :actions="false"
+              incomplete-message=" "
+            >
               <div class="mb-5 text-center">
                 <FormKit
                   :classes="{
                     input: 'border border-black py-1 px-2 rounded-md',
+                    message: 'text-red-500',
                   }"
                   type="password"
                   label="新パスワード"
@@ -32,6 +38,7 @@
                 <FormKit
                   :classes="{
                     input: 'border border-black py-1 px-2 rounded-md',
+                    message: 'text-red-500',
                   }"
                   type="password"
                   label="確認用パスワード"
@@ -50,6 +57,9 @@
                   }"
                 />
               </div>
+              <div class="flex mb-4 justify-center">
+                <button class="btn">登録</button>
+              </div>
             </FormKit>
           </div>
         </div>
@@ -60,13 +70,18 @@
 
 <script setup lang="ts">
 const router = useRouter();
+const route = useRoute();
 const supabase = useSupabaseClient();
 
 const email = ref("");
 const password = ref("");
 
 const submit = async (submit: { password: string }) => {
-  await supabase.auth.updateUser({ password: submit.password });
+  const { data, error } = await supabase.auth.updateUser({
+    password: submit.password,
+  });
+  console.log("error", error);
+  console.log(data);
 };
 </script>
 

--- a/pages/qiitaCoordination.vue
+++ b/pages/qiitaCoordination.vue
@@ -1,27 +1,25 @@
 <template>
-  <div class="flex main">
-    <div class="flex-auto my-auto">
-      <div class="flex justify-center">
-        <form @submit.prevent="submit" class="text-center">
-          <h1 class="title">Qiita連携</h1>
-          <div class="flex justify-center">
-            <div class="pb-[30px] text-left">
-              Qiita個人用アクセストークン
-              <div>
-                <input
-                  type="text"
-                  maxlength="40"
-                  class="border rounded border-black w-[300px]"
-                  v-model="text"
-                />
-              </div>
-              <p v-if="errorMessage" class="text-red-500">{{ errorMessage }}</p>
+  <div class="flex main justify-center">
+    <div class="my-auto text-center">
+      <h1 class="title">Qiita連携</h1>
+      <form @submit.prevent="submit" class="text-center">
+        <div class="flex justify-center">
+          <div class="pb-[30px] text-left">
+            Qiita個人用アクセストークン
+            <div>
+              <input
+                type="text"
+                maxlength="40"
+                class="border rounded border-black w-[300px]"
+                v-model="text"
+              />
             </div>
+            <p v-if="errorMessage" class="text-red-500">{{ errorMessage }}</p>
           </div>
+        </div>
 
-          <button type="submit" class="btn">登録</button>
-        </form>
-      </div>
+        <button type="submit" class="btn">登録</button>
+      </form>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Issue のリンク
-

## やったこと(What,How)
-　ログアウトした際に、ログイン画面のCSSが崩れるのを修正
-　ログイン状態でログイン画面のタグで記事一覧ページに遷移できるように修正
- 　パスワードリセット画面をパスワードリセットメールからのURL/ログイン状態以外で遷移できないように修正

## やらないこと
-

## できるようになること（ユーザ目線）(Why,Who)
-

## できなくなること（ユーザ目線）

-

## 動作確認
-

## タスク

-

## エラー表示内容

-

## その他
-　パスワード再設定メール送信機能で、正しいメールアドレスに送信されたのか確認できない
