### PR TITLE
新規登録のエラー分岐修正

### DIFF
--- a/pages/createAdvent.vue
+++ b/pages/createAdvent.vue
@@ -61,7 +61,7 @@ const startDate = new Date();
 const endDate = new Date(new Date().setDate(startDate.getDate() + 7));
 // date.value = [startDate, endDate];
 // });
-const date: Date[] = ref([startDate, endDate]);
+const date = ref([startDate, endDate]);
 
 // supabaseにデータを送信する
 async function submitHandler() {

--- a/pages/editAdvent/[id].vue
+++ b/pages/editAdvent/[id].vue
@@ -36,7 +36,7 @@
   </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import VueDatePicker from "@vuepic/vue-datepicker";
 import "@vuepic/vue-datepicker/dist/main.css";
 import dayjs from "dayjs";
@@ -46,6 +46,7 @@ const fileInput = ref();
 const client = useSupabaseClient();
 const user = useSupabaseUser();
 const errorMsg = ref("");
+const format = "yyyy/MM/dd";
 //バナーデータ取得
 // const { data: advent } = useFetch("/api/advent/get", {
 //   method: "POST",
@@ -56,6 +57,7 @@ const { data: advent } = await client
   .from("banner")
   .select("*")
   .eq("id", route.params.id);
+
 const bannerImage = ref(`${advent[0].image}`);
 const adventName = ref(`${advent[0].adventName}`);
 const description = ref(`${advent[0].description}`);

--- a/pages/editAdvent/[id].vue
+++ b/pages/editAdvent/[id].vue
@@ -36,10 +36,11 @@
   </div>
 </template>
 
-<script setup lang="ts">
+<script setup>
 import VueDatePicker from "@vuepic/vue-datepicker";
 import "@vuepic/vue-datepicker/dist/main.css";
 import dayjs from "dayjs";
+import { Banner } from "~/types";
 const router = useRouter();
 const route = useRoute();
 const fileInput = ref();
@@ -58,7 +59,9 @@ const { data: advent } = await client
   .select("*")
   .eq("id", route.params.id);
 
-const bannerImage = ref(`${advent[0].image}`);
+const bannerImage = ref(`${bannerData.value[0].image}`);
+
+// const bannerImage = ref(`${advent[0].image}`);
 const adventName = ref(`${advent[0].adventName}`);
 const description = ref(`${advent[0].description}`);
 const date = ref([`${advent[0].startDate}`, `${advent[0].endDate}`]);

--- a/pages/userRegister.vue
+++ b/pages/userRegister.vue
@@ -313,9 +313,11 @@ const submitHandler = async (credentials: Credentials) => {
       },
     },
   });
-  succes.value = true;
+
   if (error) {
     errormesssage.value = "既に登録されているメールアドレスです。";
+  } else {
+    succes.value = true;
   }
 };
 </script>


### PR DESCRIPTION
## Issue のリンク

- https://github.com/KonishiTatsuki/qiita-builder/issues/134

## やったこと(What,How)
- 画像のファイル名をuidにすることで、重複エラーとファイル名エラーを回避
- 既に登録済みのメールアドレスの場合→既に登録されているメールアドレスとエラー文を排出。
- エラーなかったら、クラブ追加と新規登録を進められる

## やらないこと

-

## できるようになること（ユーザ目線）(Why,Who)

-

## できなくなること（ユーザ目線）

-

## 動作確認

-

## タスク

-

## エラー表示内容



## その他

-
