### PR TITLE
👍 一覧画面、詳細画面、ヘッダー修正

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,14 +1,32 @@
 <template>
-  <header class="text-white bg-[#1D8EB9] body-font max-w-full mx-auto h-[68px] flex items-center">
+  <header
+    class="text-white bg-[#1D8EB9] body-font max-w-full mx-auto h-[68px] flex items-center"
+  >
     <div
       class="container mx-auto flex flex-wrap flex-col md:flex-row items-center"
     >
-      <NuxtLink
-        to="/"
-        class="flex title-font font-medium items-center text-gray-900 md:mb-0"
-      >
-        <span class="ml-3 text-xl text-white">Qiita Builder</span>
+    <div class="flex items-center md:mb-0">
+      <NuxtLink to="/">
+        <span class="ml-3 text-xl hover:text-gray-900">Qiita Builder</span>
       </NuxtLink>
+        <div v-if="loginUser" class="ml-5 flex flex-col">
+          <span class="text-sm text-white">ログイン中</span
+          ><span class="text-base"
+            >
+            <img
+              v-if="loginUser[0].image"
+              :src="loginUser[0].image"
+              alt="Icon"
+              class="w-5 h-5 rounded-full inline mb-1"
+            />
+            {{
+              loginUser[0].username.length > 15
+                ? loginUser[0].username.slice(0, 15) + "..."
+                : loginUser[0].username
+            }}</span
+          >
+        </div>
+      </div>
       <!-- 記事一覧ページのみで検索ボックスを表示 -->
       <template v-if="$route.path === '/'">
         <div class="absolute absolute left-1/2 transform -translate-x-1/2">
@@ -38,7 +56,7 @@
   </div>
 
   <footer class="bg-[#1D8EB9] h-[56px] mt-[44px] flex items-center">
-    <div class="container mx-auto ">
+    <div class="container mx-auto">
       <p class="text-center text-white">&copy; 2023 Qiita builder.</p>
     </div>
   </footer>
@@ -48,9 +66,20 @@
 import SearchArticle from "../components/SearchArticle.vue";
 const router = useRouter();
 const client = useSupabaseClient();
+const user = useSupabaseUser();
+const userId = user.value?.id;
+const userName = ref("");
+
 const logout = async () => {
   const { error } = await client.auth.signOut();
   console.log("ログアウト", error);
   router.push("/login");
 };
+
+const { data: loginUser } = await useFetch("/api/user/userGet", {
+  method: "POST",
+  body: userId,
+});
+console.log(loginUser.value[0]);
+console.log(loginUser.value[0].username);
 </script>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -80,6 +80,4 @@ const { data: loginUser } = await useFetch("/api/user/userGet", {
   method: "POST",
   body: userId,
 });
-console.log(loginUser.value[0]);
-console.log(loginUser.value[0].username);
 </script>

--- a/pages/articleDetail/[id].vue
+++ b/pages/articleDetail/[id].vue
@@ -37,7 +37,7 @@
         >
       </div>
 
-      <div class="text-gray-800 mb-4">
+      <div class="text-gray-800 mb-4" id="parent-element">
         <!-- tailwindcssのスタイルを無効化するcustom-proseクラス -->
         <template v-if="htmlText">
           <span class="custom-prose" v-html="htmlText"></span>
@@ -62,7 +62,7 @@
     </div>
 
     <!-- いいね数・目標までのいいね数・Qiitaオススメした人数 -->
-    <div class="md:w-1/3 m-4 p-4 bg-gray-100">
+    <div class="md:w-1/3 m-4 p-4 bg-gray-100 max-h-96">
       <div class="mb-4">
         <p class="text-gray-600 text-lg flex justify-center">
           現在の「いいね！」
@@ -128,28 +128,30 @@
         v-for="commented in commentDate"
         :key="commented.id"
       >
-        <div>
-          <span class="font-semibold">{{ commented.username }}</span>
+        <div class="mr-5 w-full">
+          <div class="flex justify-between">
+            <div class="font-semibold">{{ commented.username }}</div>
+            <button
+              class="btn"
+              @click="(open = true), (deleteItem = commented.id)"
+              v-show="commented.userId == userId"
+            >
+              削除
+            </button>
+            <Teleport to="body">
+              <div v-if="open" class="modal">
+                <div class="modal-content">
+                  <p class="mb-5">本当に削除しますか？</p>
+                  <button @click="open = false" class="btn mr-5">No</button>
+                  <button @click="deleteComment(deleteItem)" class="btn">
+                    Yes
+                  </button>
+                </div>
+              </div>
+            </Teleport>
+          </div>
           <p class="text-gray-600">{{ commented.comment }}</p>
         </div>
-        <button
-          class="text-gray-600"
-          @click="(open = true), (deleteItem = commented.id)"
-          v-show="commented.userId == userId"
-        >
-          削除
-        </button>
-        <Teleport to="body">
-          <div v-if="open" class="modal">
-            <div class="modal-content">
-              <p class="mb-5">本当に削除しますか？</p>
-              <button @click="open = false" class="btn mr-5">No</button>
-              <button @click="deleteComment(deleteItem)" class="btn">
-                Yes
-              </button>
-            </div>
-          </div>
-        </Teleport>
       </div>
     </div>
   </div>
@@ -444,5 +446,8 @@ const deleteComment = async (commentId) => {
   border: 1px solid #888;
   width: 300px;
   text-align: center;
+}
+#parent-element {
+  word-wrap: break-word;
 }
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="max-w-screen-xl mx-auto">
+  <div class="scale-75">
     <div class="flex">
       <!-- カテゴリ検索欄 -->
       <div class="flex flex-col">
@@ -121,7 +121,7 @@
           :to="{ path: `/calendar/${bannerData[0].id}` }"
         >
           <div
-            class="bg-gradient-to-r from-purple-400 via-pink-500 to-red-500 p-4 rounded-lg shadow-lg flex items-center justify-between mt-3"
+            class="bg-gradient-to-r from-purple-400 via-pink-500 to-red-500 p-4 rounded-lg shadow-lg flex items-center justify-between mt-3 max-w-[1200px]"
             :style="
               'background-image: url(' +
               (bannerData && bannerData[0]?.image) +
@@ -136,7 +136,7 @@
           </div>
         </NuxtLink>
         <!-- ソート機能 -->
-        <div class="flex justify-end">
+        <div class="flex justify-end max-w-[1200px]">
           <div class="inline-flex rounded-md shadow-sm pt-5 pb-3" role="group">
             <button
               @click="sortArticlesByDateDescending"
@@ -162,7 +162,7 @@
           </div>
         </div>
         <!-- 記事一覧 -->
-        <section class="text-gray-600 body-font overflow-hidden">
+        <section class="text-gray-600 body-font overflow-hidden max-w-[1200px]">
           <div class="container px-5 pb-24 mx-auto">
             <div
               v-if="
@@ -218,7 +218,7 @@
                       </span>
                     </div>
                   </div>
-                  <div class="md:flex-grow">
+                  <div class="md:flex-grow mr-5 overflow-hidden">
                     <router-link
                       :to="`/articleDetail/${article.id}`"
                       class="hover:underline"
@@ -261,14 +261,10 @@
                     <div class="mt-4" v-if="authority"></div>
                   </div>
                   <div>
-                    <!-- <button
-                      class="btn block h-[40px]"
-                      @click="deleteArticle(article.id)"
+                    <button
+                      @click="(open = true), (deleteItem = article.id)"
+                      class="btn h-[40px] w-[70px]"
                     >
-                      削除
-                    </button> -->
-
-                    <button @click="open = true , deleteItem = article.id" class="btn block h-[40px]">
                       削除
                     </button>
                     <Teleport to="body">
@@ -315,7 +311,6 @@ let date = new Date(); //現在の日付取得
 //モーダルの表示非表示
 const open = ref(false);
 const deleteItem = ref();
-
 
 //管理者権限があるか確認
 let { data: auth } = await useFetch("/api/user/getAdminUser", {
@@ -684,5 +679,10 @@ const deleteArticle = async (id) => {
   border: 1px solid #888;
   width: 300px;
   text-align: center;
+}
+
+.scale-75 {
+  transform: scale(0.75);
+  transform-origin: top;
 }
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -610,7 +610,6 @@ const toggleShowAllTagItems = () => {
 
 // サークルの表示数を変更する
 const toggleShowAllClubItems = () => {
-  console.log(visibleArticleData.value);
   if (showAllClubItems.value) {
     visibleClubItems.value = 10;
     showAllClubItems.value = false;


### PR DESCRIPTION
## Issue のリンク

- https://github.com/KonishiTatsuki/qiita-builder/issues/58
- https://github.com/KonishiTatsuki/qiita-builder/issues/22
- https://github.com/KonishiTatsuki/qiita-builder/issues/154

## やったこと(What,How)

- 一覧画面UI修正：削除ボタンが記事内容によって大小変化するのを修正
- 一覧画面UI修正：各記事の記事内容が枠からはみ出ないように修正
- 一覧画面UI修正：コンテンツが右寄りになっていたのを中央に配置（記事にwidthを当てたら修正できた）
- 詳細画面UI修正：記事内容が枠からはみ出ないように修正
- 詳細画面UI修正：コメント内容が枠からはみ出ないように修正
- 詳細画面UI修正：削除ボタンが記事内容によって大小変化するのを修正
- ヘッダー修正：ログイン中のユーザ名表示

## やらないこと

-

## できるようになること（ユーザ目線）(Why,Who)

- ログインしていることが確認できる

## できなくなること（ユーザ目線）

-

## 動作確認

- 済み

## タスク

-

## エラー表示内容

-

## その他

-
