### PR TITLE
マイページ/記事が5件以上になった際にアコーディオンにする

### DIFF
--- a/pages/articles/edit/[id].vue
+++ b/pages/articles/edit/[id].vue
@@ -187,7 +187,7 @@ const submitHandler = async () => {
     method: "PATCH",
     body: { postData: postData, tag: select },
   });
-  router.push("/");
+  router.push(`/articleDetail/${id}`);
 };
 
 const draftHandler = async () => {
@@ -204,7 +204,7 @@ const draftHandler = async () => {
     method: "PATCH",
     body: { postData: postData, tag: select },
   });
-  router.push("/");
+  router.push("/myPage");
 };
 
 const deleteHandler = async () => {

--- a/pages/articles/new.vue
+++ b/pages/articles/new.vue
@@ -203,7 +203,7 @@ const draftHandler = async () => {
     method: "POST",
     body: { article: postData, tagArray: select.value },
   });
-  router.push("/");
+  router.push("/myPage");
 };
 
 onMounted(async () => {


### PR DESCRIPTION
## Issue のリンク

-

## やったこと(What,How)

- マイページで記事が5件以上ある時は「もっと見る」で表示させるようにしました
- 記事編集ページ　編集完了→当該の記事詳細に遷移　下書き完了→マイページに遷移
- 記事新規投稿　下書き完了→マイページに遷移

## やらないこと

-

## できるようになること（ユーザ目線）(Why,Who)

-

## できなくなること（ユーザ目線）

-

## 動作確認
<img width="968" alt="スクリーンショット 2023-06-13 10 44 29" src="https://github.com/KonishiTatsuki/qiita-builder/assets/114968506/b74f0483-92a4-498e-8fe3-0fed8de9ad2b">


## タスク

-

## エラー表示内容

-

## その他

-
