### PR TITLE
:+1: 期間設定で2つの日付を選択しなければ登録ボタンが機能しないようにバリデーションを出す

### DIFF
--- a/pages/createAdvent.vue
+++ b/pages/createAdvent.vue
@@ -23,7 +23,6 @@
     <h2 class="subtitle">期間</h2>
     <span class="text-xs text-red-500">(必須)</span>
     <VueDatePicker v-model="date" locale="ja" :format="format" range />
-    <div>{{ date }}</div>
 
     <h2 class="subtitle">バナー画像</h2>
     <div>
@@ -71,6 +70,8 @@ async function submitHandler() {
     errorMsg.value = "アドベントカレンダーの題名を入力してください";
   } else if (!description.value) {
     errorMsg.value = "アドベントカレンダーの説明を入力してください";
+  } else if (!date.value[0] || !date.value[1]) {
+    errorMsg.value = "期間の開始日と最終日を選択してください";
   } else if (!fileInput.value.files[0]) {
     errorMsg.value = "画像を選択してください";
   } else {

--- a/pages/editAdvent/[id].vue
+++ b/pages/editAdvent/[id].vue
@@ -70,6 +70,13 @@ const editSubmit = async () => {
   let startDate = dayjs(date.value[0]).format("YYYY-MM-DD");
   let endDate = dayjs(date.value[1]).format("YYYY-MM-DD");
   errorMsg.value = "";
+
+  if (!date.value || date.value[1] === null) {
+    errorMsg.value = "期間の開始日と最終日を選択してください";
+    return;
+  }
+  console.log(date.value);
+
   //バナー画像が編集された時
   if (fileInput.value.files[0]) {
     if (adventName.value.length === 0) {


### PR DESCRIPTION
## Issue のリンク

-

## やったこと(What,How)

- 新規アドベント作成とアドベント編集画面の期間の日付を開始日と終了日の2つの日付を選択しなければバリデーションをだすようにした

## やらないこと

-

## できるようになること（ユーザ目線）(Why,Who)

-

## できなくなること（ユーザ目線）

-

## 動作確認

-

## タスク

-

## エラー表示内容

-

## その他

-
