### PR TITLE
:recycle: API通信をNuxtのサーバールート経由に変更

### DIFF
--- a/pages/ownerPage.vue
+++ b/pages/ownerPage.vue
@@ -63,7 +63,7 @@
               <li>
                 <input
                   type="radio"
-                  :value="{ id: `${display.value}`, display: false }"
+                  :value="{ id: `${display.value}` }"
                   v-model="addnonDisplayClub"
                 />{{ display.label }}
               </li>
@@ -96,7 +96,7 @@
               <li>
                 <input
                   type="radio"
-                  :value="{ id: `${display.value}`, display: true }"
+                  :value="{ id: `${display.value}` }"
                   v-model="addDisplayClub"
                 />
                 {{ display.label }}
@@ -337,7 +337,10 @@ const addDisplay = async () => {
   if (addDisplayClub.value === undefined) {
     msgForaddDisplayClub.value = "サークルを選択してください";
   } else {
-    await client.from("club").upsert(addDisplayClub.value);
+    await useFetch("/api/club/displayClub", {
+      method: "PATCH",
+      body: { displayClub: addDisplayClub.value },
+    });
   }
 };
 
@@ -346,7 +349,10 @@ const nonDisplay = async () => {
   if (addnonDisplayClub.value === undefined) {
     msgForaddnonDisplayClub.value = "サークルを選択してください";
   } else {
-    await client.from("club").upsert(addnonDisplayClub.value);
+    await useFetch("/api/club/nonDisplayClub", {
+      method: "PATCH",
+      body: { nondisplayClub: addnonDisplayClub.value },
+    });
   }
 };
 
@@ -367,9 +373,13 @@ const addNewClub = async () => {
   } else if (newclub.value.length > 30) {
     msgForaddDisplayClub.value = "30字以内で入力してください";
   } else {
-    await client.from("club").insert({
-      clubName: newclub.value,
+    const { data: response } = await useFetch("/api/club/newClub", {
+      method: "POST",
+      body: { newclub: newclub.value },
     });
+    if (response.value === "登録済み") {
+      msgForaddDisplayClub.value = "このサークルは既に登録されています";
+    }
   }
 };
 

--- a/server/api/club/displayClub.ts
+++ b/server/api/club/displayClub.ts
@@ -1,0 +1,15 @@
+import { serverSupabaseClient } from "#supabase/server";
+import { Database } from "~/types/database.types";
+
+export default defineEventHandler(async (event) => {
+  const supabase = serverSupabaseClient<Database>(event);
+  const body = await readBody(event);
+
+  // 非表示から表示に変更
+  const { data } = await supabase
+    .from("club")
+    .update({ display: true })
+    .eq("id", body.displayClub.id);
+
+  return "表示に変更";
+});

--- a/server/api/club/newClub.ts
+++ b/server/api/club/newClub.ts
@@ -1,0 +1,24 @@
+import { serverSupabaseClient } from "#supabase/server";
+import { Database } from "~/types/database.types";
+
+export default defineEventHandler(async (event) => {
+  const supabase = serverSupabaseClient<Database>(event);
+  const body = await readBody(event);
+
+  // クラブが既に存在しているか確認する
+  const { data } = await supabase
+    .from("club")
+    .select("*")
+    .eq("clubName", body.newclub);
+
+  // 存在していない場合、新しく追加する
+  if (data?.length === 0) {
+    await supabase
+      .from("club")
+      .insert({ clubName: body.newclub, display: false, count: 1 })
+      .select();
+    return "登録完了";
+  } else {
+    return "登録済み";
+  }
+});

--- a/server/api/club/nonDisplayClub.ts
+++ b/server/api/club/nonDisplayClub.ts
@@ -1,0 +1,15 @@
+import { serverSupabaseClient } from "#supabase/server";
+import { Database } from "~/types/database.types";
+
+export default defineEventHandler(async (event) => {
+  const supabase = serverSupabaseClient<Database>(event);
+  const body = await readBody(event);
+
+  // 表示から非表示に変更
+  const { data } = await supabase
+    .from("club")
+    .update({ display: false })
+    .eq("id", body.nondisplayClub.id);
+
+  return "非表示に変更";
+});


### PR DESCRIPTION
## Issue のリンク

-

## やったこと(What,How)

- テストをやりやすくするために、supabaseに直接投げていたものをNuxtのサーバーに投げるようにした
- 同じ名前のサークルが登録できるようになっていたため、重複を避けるようにした
- input(ラジオボタン)でvalueにいらない項目があったため、削除

## やらないこと

-

## できるようになること（ユーザ目線）(Why,Who)

-

## できなくなること（ユーザ目線）

-

## 動作確認

-

## タスク

-

## エラー表示内容

-

## その他

-
