### PR TITLE
管理者ページのテスト実施

### DIFF
--- a/components/ownerPage/ClubFunction.vue
+++ b/components/ownerPage/ClubFunction.vue
@@ -1,0 +1,176 @@
+<template>
+  <div class="flex my-20">
+    <div class="w-1/5">タグ編集：</div>
+    <div class="w-4/5 flex">
+      <div class="border border-black p-4 min-w-[420px] mr-2">
+        <p class="font-bold">認証済みサークルタグ</p>
+        <hr />
+        <div class="mt-6">
+          <ul class="flex" v-for="display in displayClub">
+            <li>
+              <input
+                type="radio"
+                :value="{ id: `${display.value}` }"
+                v-model="addnonDisplayClub"
+                :id="`nonDisplayclub${display.value}`"
+              />{{ display.label }}
+            </li>
+          </ul>
+        </div>
+        <div class="text-red-500" id="msgForaddnonDisplayClub">
+          {{ msgForaddnonDisplayClub }}
+        </div>
+        <div class="flex justify-end">
+          <div class="mr-2">
+            <button
+              class="btn p-1"
+              @click="nonDisplay"
+              id="addnonDisplayClubBtn"
+            >
+              非表示
+            </button>
+          </div>
+        </div>
+      </div>
+      <div class="border border-black p-4 min-w-[420px] ml-2">
+        <p class="font-bold">未認証サークルタグ</p>
+        <hr />
+        <div class="flex mt-6">
+          <div>
+            <input
+              type="text"
+              class="border border-black ml-2 p-1"
+              v-model="newclub"
+              id="newClub"
+            />
+          </div>
+          <div>
+            <button class="ml-2 p-1 btn" @click="addNewClub">追加</button>
+          </div>
+        </div>
+        <div class="mt-3">
+          <ul
+            class="flex"
+            v-for="display in nondisplayClub"
+            id="addDisplayClubSelect"
+          >
+            <li>
+              <input
+                type="radio"
+                :value="{ id: `${display.value}` }"
+                v-model="addDisplayClub"
+                :id="`displayClub${display.value}`"
+              />
+              {{ display.label }}
+            </li>
+          </ul>
+        </div>
+        <div class="text-red-500" id="msgForaddDisplayClub">
+          {{ msgForaddDisplayClub }}
+        </div>
+        <div class="flex justify-end">
+          <div class="mr-2">
+            <button class="btn p-1" @click="clubModal = true" id="deleteBtn">
+              削除
+            </button>
+          </div>
+          <Teleport to="body" id="modal">
+            <div v-if="clubModal" class="modal">
+              <div class="modal-content">
+                <p class="mb-5">本当に削除しますか？</p>
+                <button @click="clubModal = false" class="btn mr-5">No</button>
+                <button @click="deleteClub" class="btn" id="deleteConfirmBtn">
+                  Yes
+                </button>
+                <div class="text-red-500">{{ msgForDeleteClub }}</div>
+              </div>
+            </div>
+          </Teleport>
+          <div>
+            <button class="btn p-1" @click="addDisplay" id="addDisplayClubBtn">
+              表示
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, reactive } from "vue";
+import { useFetch } from "@vueuse/core";
+import axios from "axios";
+
+//display:trueのクラブ
+const displayClub = reactive([
+  { value: 3, label: "バドミントン" },
+  { value: 4, label: "テニス" },
+  { value: 5, label: "陸上" },
+]);
+//display:falseのクラブ
+const nondisplayClub = reactive([
+  { value: 0, label: "バレー" },
+  { value: 1, label: "野球" },
+  { value: 2, label: "サッカー" },
+]);
+
+//新規追加クラブ
+const newclub = ref("");
+
+const addDisplayClub = ref("");
+const msgForaddDisplayClub = ref();
+const msgForaddnonDisplayClub = ref();
+const msgForDeleteClub = ref();
+const addnonDisplayClub = ref();
+
+//表示するサークルの追加
+const addDisplay = async () => {
+  if (addDisplayClub.value === undefined) {
+    msgForaddDisplayClub.value = "サークルを選択してください";
+  } else {
+    await axios.patch("/api/club/displayClub", {
+      displayClub: addDisplayClub.value,
+    });
+  }
+};
+
+//サークルを非表示にする
+const nonDisplay = async () => {
+  if (addnonDisplayClub.value === undefined) {
+    msgForaddnonDisplayClub.value = "サークルを選択してください";
+  } else {
+    await axios.patch("/api/club/nonDisplayClub", {
+      nondisplayClub: addnonDisplayClub.value,
+    });
+  }
+};
+
+//表示するサークルの削除
+const deleteClub = async () => {
+  if (addDisplayClub.value === undefined) {
+    msgForDeleteClub.value = "サークルを選択してください";
+  } else {
+    const deleteClubId = addDisplayClub.value.id;
+    await axios.delete(`/api/club/delete?clubid=${deleteClubId}`);
+  }
+};
+
+//新規クラブの追加
+const addNewClub = async () => {
+  if (!newclub.value) {
+    msgForaddDisplayClub.value = "追加するサークル名を入力してください";
+  } else if (newclub.value.length > 30) {
+    msgForaddDisplayClub.value = "30字以内で入力してください";
+  } else {
+    const { data: response } = await axios.post("/api/club/newClub", {
+      newclub: newclub.value,
+    });
+    if (response.value === "登録済み") {
+      msgForaddDisplayClub.value = "このサークルは既に登録されています";
+    }
+  }
+};
+</script>
+
+<style></style>

--- a/components/ownerPage/SubmitOwner.vue
+++ b/components/ownerPage/SubmitOwner.vue
@@ -1,7 +1,8 @@
 <script setup>
 import { ref, reactive } from "vue";
-const errormsg = ref("");
+import axios from "axios";
 
+const errormsg = ref("");
 const ownerList = reactive([]);
 const owner = ref();
 //新規管理者の保存
@@ -13,15 +14,13 @@ const submitOwner = async () => {
   } else {
     //ラクスメールアドレス形式のバリデーション
     if (re.test(owner.value)) {
-      const response = await axios.patch(`api/owner/register`, {
-        mailAddress: owner.value,
-        authority: true,
+      const { data, error } = await axios.patch("/api/user/ownerRegister", {
+        body: { email: owner.value },
       });
-
-      if (data && data.length > 0) {
-        console.log("完了");
-      } else if (data && data.length === 0) {
+      if (data.value === "Not Found") {
         errormsg.value = "該当のメールアドレスが見つかりません";
+      } else {
+        console.log("登録完了");
       }
     } else {
       errormsg.value = "メールアドレスの形式が不正です";
@@ -31,7 +30,10 @@ const submitOwner = async () => {
 
 //owner権限の削除
 const deleteOwner = async (id) => {
-  await client.from("profiles").upsert({ id: id, authority: false });
+  await useFetch("/api/user/ownerDelete", {
+    method: "PATCH",
+    body: { id: id },
+  });
 };
 </script>
 
@@ -49,11 +51,12 @@ const deleteOwner = async (id) => {
             class="border border-black w-80"
             maxlength="255"
             v-model="owner"
+            id="inputEmail"
           />
         </div>
         <div><button class="btn ml-4" @click="submitOwner">保存</button></div>
       </div>
-      <p class="text-red-500">{{ errormsg }}</p>
+      <p class="text-red-500" id="errormsg">{{ errormsg }}</p>
       <div class="mt-5">
         <div>
           <table

--- a/components/ownerPage/SubmitOwner.vue
+++ b/components/ownerPage/SubmitOwner.vue
@@ -1,0 +1,101 @@
+<script setup>
+import { ref, reactive } from "vue";
+const errormsg = ref("");
+
+const ownerList = reactive([]);
+const owner = ref();
+//新規管理者の保存
+const submitOwner = async () => {
+  errormsg.value = "";
+  const re = /^[a-zA-Z0-9_+-]+(.[a-zA-Z0-9_+-]+)*@rakus-partners.co.jp/;
+  if (!owner.value) {
+    errormsg.value = "メールアドレスを入力してください";
+  } else {
+    //ラクスメールアドレス形式のバリデーション
+    if (re.test(owner.value)) {
+      const response = await axios.patch(`api/owner/register`, {
+        mailAddress: owner.value,
+        authority: true,
+      });
+
+      if (data && data.length > 0) {
+        console.log("完了");
+      } else if (data && data.length === 0) {
+        errormsg.value = "該当のメールアドレスが見つかりません";
+      }
+    } else {
+      errormsg.value = "メールアドレスの形式が不正です";
+    }
+  }
+};
+
+//owner権限の削除
+const deleteOwner = async (id) => {
+  await client.from("profiles").upsert({ id: id, authority: false });
+};
+</script>
+
+<template>
+  <div class="mt-5 flex my-16">
+    <div class="w-1/5">管理者権限：</div>
+    <div class="w-4/5">
+      <p class="mb-3">
+        管理者権限を与えたい社員のメールアドレスを入力してください
+      </p>
+      <div class="flex items-center">
+        <div>
+          <input
+            type="text"
+            class="border border-black w-80"
+            maxlength="255"
+            v-model="owner"
+          />
+        </div>
+        <div><button class="btn ml-4" @click="submitOwner">保存</button></div>
+      </div>
+      <p class="text-red-500">{{ errormsg }}</p>
+      <div class="mt-5">
+        <div>
+          <table
+            class="border-collapse border border-slate-500 border-spacing-2 my-12"
+          >
+            <thead>
+              <tr>
+                <th colspan="3">管理者一覧</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="item in ownerList">
+                <td class="border border-slate-500 px-2 max w-[400px]">
+                  ユーザ名：{{ item.username }}
+                </td>
+                <td class="border border-slate-500 px-2 max w-[400px]">
+                  {{ item.email }}
+                </td>
+                <td class="border border-slate-500 px-2 w-[70px]">
+                  <button
+                    class="btn px-2"
+                    @click="(open = true), (deleteItem = item.id)"
+                  >
+                    削除
+                  </button>
+                </td>
+                <Teleport to="body">
+                  <div v-if="open" class="modal">
+                    <div class="modal-content">
+                      <p class="mb-5">本当に削除しますか？</p>
+                      <button @click="open = false" class="btn mr-5">No</button>
+                      <button @click="deleteOwner(deleteItem)" class="btn">
+                        Yes
+                      </button>
+                    </div>
+                  </div>
+                </Teleport>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/components/ownerPage/registerAdvent.vue
+++ b/components/ownerPage/registerAdvent.vue
@@ -1,0 +1,39 @@
+<template>
+  <div class="flex items-center my-16">
+    <div class="w-1/5">バナー表示：</div>
+    <div class="w-4/5">
+      <select
+        name=""
+        id="displayValue"
+        class="border border-black w-80"
+        v-model="choseAdvent"
+      >
+        <option v-for="item in advent" :value="item.id">
+          {{ item.adventName }}
+        </option>
+      </select>
+      <span class="btn ml-4" @click="registerAdvent">保存</span>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+import axios from "axios";
+
+const showAdvent = ref(1);
+
+//選択の初期値は、現在表示されている値
+const choseAdvent = ref(1);
+
+//アドベントカレンダーの表示
+const registerAdvent = async () => {
+  await axios.post("/api/advent/chooseAdvent", {
+    currentAdventValue: showAdvent.value,
+    newAdventValue: choseAdvent.value,
+  });
+  location.reload();
+};
+</script>
+
+<style></style>

--- a/pages/ownerPage.vue
+++ b/pages/ownerPage.vue
@@ -288,13 +288,13 @@ const choseEditAdvent = ref(`${showAdvent.value?.id}`);
 
 //アドベントカレンダーの表示
 const registerAdvent = async () => {
-  console.log("aaa", choseAdvent.value);
-  //選択したアドベントをtrue
-  await client.from("banner").upsert({ id: choseAdvent.value, display: true });
-  //初期のアドベントをfalse
-  await client
-    .from("banner")
-    .upsert({ id: showAdvent.value?.id, display: false });
+  await useFetch("/api/advent/chooseAdvent", {
+    method: "POST",
+    body: {
+      currentAdventValue: showAdvent.value?.id,
+      newAdventValue: choseAdvent.value,
+    },
+  });
   location.reload();
 };
 

--- a/pages/ownerPage.vue
+++ b/pages/ownerPage.vue
@@ -400,7 +400,7 @@ const submitOwner = async () => {
   } else {
     //ラクスメールアドレス形式のバリデーション
     if (re.test(owner.value)) {
-      const { data, error } = await useFetch("/api/user/ownerRegister", {
+      const { data } = await useFetch("/api/user/ownerRegister", {
         method: "PATCH",
         body: { email: owner.value },
       });
@@ -417,7 +417,10 @@ const submitOwner = async () => {
 
 //owner権限の削除
 const deleteOwner = async (id: number) => {
-  await client.from("profiles").upsert({ id: id, authority: false });
+  await useFetch("/api/user/ownerDelete", {
+    method: "PATCH",
+    body: { id: id },
+  });
 };
 </script>
 

--- a/pages/ownerPage.vue
+++ b/pages/ownerPage.vue
@@ -286,7 +286,7 @@ const choseAdvent = ref(`${showAdvent.value?.id}`);
 //初期表示は現在のアドベントとして保存されているもの
 const choseEditAdvent = ref(`${showAdvent.value?.id}`);
 
-//アドベントカレンダーの保存
+//アドベントカレンダーの表示
 const registerAdvent = async () => {
   console.log("aaa", choseAdvent.value);
   //選択したアドベントをtrue
@@ -400,15 +400,14 @@ const submitOwner = async () => {
   } else {
     //ラクスメールアドレス形式のバリデーション
     if (re.test(owner.value)) {
-      const { data, error } = await client
-        .from("profiles")
-        .update({ authority: true })
-        .eq("email", owner.value)
-        .select();
-      if (data && data.length > 0) {
-        console.log("完了");
-      } else if (data && data.length === 0) {
+      const { data, error } = await useFetch("/api/user/ownerRegister", {
+        method: "PATCH",
+        body: { email: owner.value },
+      });
+      if (data.value === "Not Found") {
         errormsg.value = "該当のメールアドレスが見つかりません";
+      } else {
+        console.log("登録完了");
       }
     } else {
       errormsg.value = "メールアドレスの形式が不正です";

--- a/pages/ownerPage.vue
+++ b/pages/ownerPage.vue
@@ -308,7 +308,6 @@ type useClub = {
 };
 //display:trueのクラブ
 const displayClub: useClub[] = reactive([]);
-console.log(displayClub);
 //display:falseのクラブ
 const nondisplayClub: useClub[] = reactive([]);
 

--- a/pages/ownerPage.vue
+++ b/pages/ownerPage.vue
@@ -125,7 +125,6 @@
         </div>
       </div>
     </div>
-    <div></div>
 
     <!-- 管理者権限  -->
     <div class="mt-5 flex my-16">
@@ -309,6 +308,7 @@ type useClub = {
 };
 //display:trueのクラブ
 const displayClub: useClub[] = reactive([]);
+console.log(displayClub);
 //display:falseのクラブ
 const nondisplayClub: useClub[] = reactive([]);
 

--- a/server/api/advent/chooseAdvent.ts
+++ b/server/api/advent/chooseAdvent.ts
@@ -1,0 +1,17 @@
+import { serverSupabaseClient } from "#supabase/server";
+import { Database } from "~/types/database.types";
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event);
+  const client = serverSupabaseClient<Database>(event);
+  await client
+    .from("banner")
+    .update({ display: true })
+    .eq("id", body.newAdventValue);
+  await client
+    .from("banner")
+    .update({ display: false })
+    .eq("id", body.currentAdventValue);
+
+  return "OK";
+});

--- a/server/api/club/delete.ts
+++ b/server/api/club/delete.ts
@@ -1,6 +1,4 @@
 import { serverSupabaseClient } from "#supabase/server";
-import { PostgrestSingleResponse } from "@supabase/supabase-js";
-import { Article } from "~/types";
 
 export default defineEventHandler(async (event) => {
   const supabase = serverSupabaseClient(event);

--- a/server/api/user/ownerDelete.ts
+++ b/server/api/user/ownerDelete.ts
@@ -1,0 +1,11 @@
+import { serverSupabaseClient } from "#supabase/server";
+import { Database } from "~/types/database.types";
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event);
+  console.log(body);
+  const client = serverSupabaseClient<Database>(event);
+  await client.from("profiles").update({ authority: false }).eq("id", body.id);
+
+  return "OK";
+});

--- a/server/api/user/ownerDelete.ts
+++ b/server/api/user/ownerDelete.ts
@@ -3,7 +3,6 @@ import { Database } from "~/types/database.types";
 
 export default defineEventHandler(async (event) => {
   const body = await readBody(event);
-  console.log(body);
   const client = serverSupabaseClient<Database>(event);
   await client.from("profiles").update({ authority: false }).eq("id", body.id);
 

--- a/server/api/user/ownerRegister.ts
+++ b/server/api/user/ownerRegister.ts
@@ -1,0 +1,20 @@
+import { serverSupabaseClient } from "#supabase/server";
+import { Database } from "~/types/database.types";
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event);
+  console.log(body);
+  const client = serverSupabaseClient<Database>(event);
+  const { data: userId } = await client
+    .from("profiles")
+    .select("id")
+    .eq("email", body.email);
+  if (userId?.length !== 0) {
+    userId?.map(async (id) => {
+      await client.from("profiles").update({ authority: true }).eq("id", id.id);
+    });
+    return "OK";
+  } else {
+    return "Not Found";
+  }
+});

--- a/server/api/user/ownerRegister.ts
+++ b/server/api/user/ownerRegister.ts
@@ -3,7 +3,6 @@ import { Database } from "~/types/database.types";
 
 export default defineEventHandler(async (event) => {
   const body = await readBody(event);
-  console.log(body);
   const client = serverSupabaseClient<Database>(event);
   const { data: userId } = await client
     .from("profiles")

--- a/test/owner.test.js
+++ b/test/owner.test.js
@@ -1,19 +1,79 @@
 import submitOwner from "../components/ownerPage/SubmitOwner.vue"; // テスト対象のページ
 import { mount } from "@vue/test-utils";
+import axios from "axios";
 
 describe("ownerPage", () => {
-  test("should make a POST request to the correct endpoint", async () => {
+  test("ページが初期の状態でマウントされているか確認", async () => {
     const wrapper = mount(submitOwner);
-    // console.log(wrapper.html());
+
     expect(wrapper.text()).toContain("管理者権限");
-    // モックサーバーからの応答を確認したい
-    // マイページに遷移できているか確認したい
+
+    const errormsg = wrapper.find("#errormsg");
+    expect(errormsg.text()).toBe("");
   });
-  // test("should make a POST request to the correct endpoint", async () => {
-  //   const wrapper = mount(Handler);
-  //   console.log(wrapper.html());
-  //   expect(wrapper.html()).toBe("管理者画面");
-  //   // モックサーバーからの応答を確認したい
-  //   // マイページに遷移できているか確認したい
-  // });
+
+  test("メールアドレスが空で関数が実行された際のエラー", async () => {
+    const wrapper = mount(submitOwner);
+
+    const inputEmail = wrapper.find("#inputEmail");
+    await inputEmail.setValue("");
+    await wrapper.vm.submitOwner();
+
+    const errormsg = wrapper.find("#errormsg");
+    expect(errormsg.text()).toBe("メールアドレスを入力してください");
+  });
+
+  test("メールアドレスが不正な形式で関数が実行された際のエラー", async () => {
+    const wrapper = mount(submitOwner);
+
+    const inputEmail = wrapper.find("#inputEmail");
+    await inputEmail.setValue("m@rakus");
+    await wrapper.vm.submitOwner();
+
+    const errormsg = wrapper.find("#errormsg");
+    expect(errormsg.text()).toBe("メールアドレスの形式が不正です");
+  });
+
+  test("管理者権限を与えるテスト", async () => {
+    const mockResponse = { data: { message: "Success" } };
+    jest.spyOn(axios, "patch").mockResolvedValue(mockResponse);
+
+    const wrapper = mount(submitOwner);
+
+    //　インプットに入力して関数実行
+    // const inputEmail = wrapper.find("#inputEmail");
+    // await inputEmail.setValue("m@rakus-partners.co.jp");
+    // await wrapper.vm.submitOwner();
+
+    // API通信で成功が返ってくるか
+    const response = await axios.patch("/api/user/ownerRegister", {
+      body: { email: "m@rakus-partners.co.jp" },
+    });
+    expect(axios.patch).toHaveBeenCalledWith("/api/user/ownerRegister", {
+      body: { email: "m@rakus-partners.co.jp" },
+    });
+    // 成功メッセージが表示されることを確認
+    expect(response.data).toEqual({ message: "Success" });
+
+    const errormsg = wrapper.find("#errormsg");
+    expect(errormsg.text()).toBe("");
+  });
+
+  test("管理者権限を削除するテスト", async () => {
+    const mockResponse = { data: { message: "Success" } };
+    jest.spyOn(axios, "patch").mockResolvedValue(mockResponse);
+
+    const wrapper = mount(submitOwner);
+
+    //　インプットに入力して関数実行
+    // API通信で成功が返ってくるか
+    const response = await axios.patch("/api/user/ownerDelete", {
+      body: { id: "1" },
+    });
+    expect(axios.patch).toHaveBeenCalledWith("/api/user/ownerDelete", {
+      body: { id: "1" },
+    });
+    // 成功メッセージが表示されることを確認
+    expect(response.data).toEqual({ message: "Success" });
+  });
 });

--- a/test/owner.test.js
+++ b/test/owner.test.js
@@ -1,33 +1,19 @@
-import { setupServer } from "msw/node";
-import { rest } from "msw";
-import Handler from "../pages/ownerPage"; // テスト対象のページ
+import submitOwner from "../components/ownerPage/SubmitOwner.vue"; // テスト対象のページ
 import { mount } from "@vue/test-utils";
 
-// モックサーバーの設定
-// const server = setupServer(
-//   rest.post("/api/article/post", (req, res, ctx) => {
-//     // モックのレスポンスを返す
-//     return res(ctx.status(201));
-//   })
-// );
-// beforeAll(() => {
-//   server.listen();
-// });
-// afterAll(() => {
-//   server.close();
-// });
-describe("submitHandler", () => {
+describe("ownerPage", () => {
   test("should make a POST request to the correct endpoint", async () => {
-    const wrapper = mount(Handler);
-    console.log(wrapper.html());
-    expect(wrapper.html()).toBe("管理者画面");
-    // const title = wrapper.find("#title");
-    // await title.setValue("dammyTitle");
-    // const content = wrapper.find("#content");
-    // await content.setValue("dammyContent");
-    // await wrapper.find("button").trigger("click");
-
+    const wrapper = mount(submitOwner);
+    // console.log(wrapper.html());
+    expect(wrapper.text()).toContain("管理者権限");
     // モックサーバーからの応答を確認したい
     // マイページに遷移できているか確認したい
   });
+  // test("should make a POST request to the correct endpoint", async () => {
+  //   const wrapper = mount(Handler);
+  //   console.log(wrapper.html());
+  //   expect(wrapper.html()).toBe("管理者画面");
+  //   // モックサーバーからの応答を確認したい
+  //   // マイページに遷移できているか確認したい
+  // });
 });

--- a/test/ownerPage/addDisplayClub.test.js
+++ b/test/ownerPage/addDisplayClub.test.js
@@ -35,7 +35,6 @@ describe("addDisplayClubFunction", () => {
     // POSTリクエストの実行
     await wrapper.find("#addDisplayClubBtn").trigger("click");
     const errorMsg = wrapper.vm.msgForaddDisplayClub;
-    console.log(wrapper.vm.msgForaddDisplayClub);
     expect(errorMsg).toBe("サークルを選択してください");
   });
 

--- a/test/ownerPage/addDisplayClub.test.js
+++ b/test/ownerPage/addDisplayClub.test.js
@@ -1,0 +1,63 @@
+import addDisplayClubFunction from "../../components/ownerPage/ClubFunction.vue"; // テスト対象のページ
+import { mount } from "@vue/test-utils";
+import axios from "axios";
+import { rest } from "msw";
+import { setupServer } from "msw/node";
+
+// MSWでサーバーのモック作成;
+const server = setupServer(
+  rest.patch("/api/club/displayClub", (req, res, ctx) => {
+    return res(ctx.json({ message: "Success" }));
+  })
+);
+beforeAll(() => {
+  server.listen();
+});
+beforeEach(() => {
+  jest.restoreAllMocks();
+});
+afterEach(() => {
+  server.resetHandlers();
+});
+afterAll(() => {
+  server.close();
+});
+
+describe("addDisplayClubFunction", () => {
+  test("ページがマウントできているか確認", async () => {
+    const wrapper = mount(addDisplayClubFunction);
+    expect(wrapper.text()).toContain("タグ編集：");
+  });
+
+  test("何も選択せずにボタンを押下した場合", async () => {
+    // コンポーネントのマウント
+    const wrapper = mount(addDisplayClubFunction);
+    // POSTリクエストの実行
+    await wrapper.find("#addDisplayClubBtn").trigger("click");
+    const errorMsg = wrapper.vm.msgForaddDisplayClub;
+    console.log(wrapper.vm.msgForaddDisplayClub);
+    expect(errorMsg).toBe("サークルを選択してください");
+  });
+
+  test("value:1のラジオボタンを選んでボタンを押下", async () => {
+    // コンポーネントのマウント
+    const wrapper = mount(addDisplayClubFunction);
+
+    // valueが1のラジオボタンを確認
+    const radioInput = wrapper.find('input[type="radio"][id="displayClub1"]');
+    expect(radioInput.wrapperElement._value.id).toEqual("1");
+
+    //チェックをして、送信
+    await radioInput.setChecked();
+    await wrapper.find("#addDisplayClubBtn").trigger("click");
+
+    const response = await axios.patch("/api/club/displayClub", {
+      displayClub: radioInput.wrapperElement._value.id,
+    });
+    // 成功メッセージが表示されることを確認
+    expect(response.data).toEqual({ message: "Success" });
+
+    // エラーメッセージも表示されていないことを確認
+    expect(wrapper.text()).not.toContain("サークルを選択してください");
+  });
+});

--- a/test/ownerPage/addNewClub.test.js
+++ b/test/ownerPage/addNewClub.test.js
@@ -43,7 +43,6 @@ describe("addDisplayClubFunction", () => {
     // // POSTリクエストの実行
     await wrapper.vm.addNewClub();
     const errorMsg = wrapper.vm.msgForaddDisplayClub;
-    console.log(wrapper.vm.msgForaddDisplayClub);
     expect(errorMsg).toBe("追加するサークル名を入力してください");
   });
   test("サークル名を31字で記入し、ボタンを押下した場合", async () => {
@@ -56,7 +55,7 @@ describe("addDisplayClubFunction", () => {
     );
     await wrapper.vm.addNewClub();
     const errorMsg = wrapper.vm.msgForaddDisplayClub;
-    console.log(wrapper.vm.msgForaddDisplayClub);
+
     expect(errorMsg).toBe("30字以内で入力してください");
   });
 

--- a/test/ownerPage/addNewClub.test.js
+++ b/test/ownerPage/addNewClub.test.js
@@ -1,0 +1,84 @@
+import addNewClubFunction from "../../components/ownerPage/ClubFunction.vue"; // テスト対象のページ
+import { mount } from "@vue/test-utils";
+import axios from "axios";
+import { rest } from "msw";
+import { setupServer } from "msw/node";
+
+// MSWでサーバーのモック作成;
+const server = setupServer(
+  rest.post("/api/club/newClub", (req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json([
+        {
+          value: 7,
+          label: "フットサル",
+        },
+      ])
+    );
+  })
+);
+beforeAll(() => {
+  server.listen();
+});
+beforeEach(() => {
+  jest.restoreAllMocks();
+});
+afterEach(() => {
+  server.resetHandlers();
+});
+afterAll(() => {
+  server.close();
+});
+
+describe("addDisplayClubFunction", () => {
+  test("ページがマウントできているか確認", async () => {
+    const wrapper = mount(addNewClubFunction);
+    expect(wrapper.text()).toContain("タグ編集：");
+  });
+
+  test("何も選択せずにボタンを押下した場合", async () => {
+    // コンポーネントのマウント
+    const wrapper = mount(addNewClubFunction);
+    // // POSTリクエストの実行
+    await wrapper.vm.addNewClub();
+    const errorMsg = wrapper.vm.msgForaddDisplayClub;
+    console.log(wrapper.vm.msgForaddDisplayClub);
+    expect(errorMsg).toBe("追加するサークル名を入力してください");
+  });
+  test("サークル名を31字で記入し、ボタンを押下した場合", async () => {
+    // コンポーネントのマウント
+    const wrapper = mount(addNewClubFunction);
+    // // POSTリクエストの実行
+    const inputClub = wrapper.find("#newClub");
+    inputClub.setValue(
+      "ぁあぃいぅうぇえぉおかがきぎくぐけげこごさざしじすずせぜそぞた"
+    );
+    await wrapper.vm.addNewClub();
+    const errorMsg = wrapper.vm.msgForaddDisplayClub;
+    console.log(wrapper.vm.msgForaddDisplayClub);
+    expect(errorMsg).toBe("30字以内で入力してください");
+  });
+
+  test("value:1のラジオボタンを選んでボタンを押下", async () => {
+    // コンポーネントのマウント
+    const wrapper = mount(addNewClubFunction);
+
+    const inputClub = wrapper.find("#newClub");
+    inputClub.setValue("フットサル");
+    await wrapper.vm.addNewClub();
+
+    const response = await axios.post("/api/club/newClub", {
+      label: "フットサル",
+    });
+    // // 成功メッセージが表示されることを確認
+    expect(response.data).toEqual([
+      {
+        value: 7,
+        label: "フットサル",
+      },
+    ]);
+    // // エラーメッセージも表示されていないことを確認
+    expect(wrapper.text()).not.toContain("サークルを選択してください");
+  });
+});

--- a/test/ownerPage/addNonDisplayClub.test.js
+++ b/test/ownerPage/addNonDisplayClub.test.js
@@ -35,7 +35,6 @@ describe("addDisplayClubFunction", () => {
     // // POSTリクエストの実行
     await wrapper.find("#addnonDisplayClubBtn").trigger("click");
     const errorMsg = wrapper.vm.msgForaddnonDisplayClub;
-    console.log(wrapper.vm.msgForaddnonDisplayClub);
     expect(errorMsg).toBe("サークルを選択してください");
   });
 

--- a/test/ownerPage/addNonDisplayClub.test.js
+++ b/test/ownerPage/addNonDisplayClub.test.js
@@ -1,0 +1,61 @@
+import addNonDisplayClubFunction from "../../components/ownerPage/ClubFunction.vue"; // テスト対象のページ
+import { mount } from "@vue/test-utils";
+import axios from "axios";
+import { rest } from "msw";
+import { setupServer } from "msw/node";
+
+// MSWでサーバーのモック作成;
+const server = setupServer(
+  rest.patch("/api/club/nonDisplayClub", (req, res, ctx) => {
+    return res(ctx.json({ message: "Success" }));
+  })
+);
+beforeAll(() => {
+  server.listen();
+});
+beforeEach(() => {
+  jest.restoreAllMocks();
+});
+afterEach(() => {
+  server.resetHandlers();
+});
+afterAll(() => {
+  server.close();
+});
+
+describe("addDisplayClubFunction", () => {
+  test("ページがマウントできているか確認", async () => {
+    const wrapper = mount(addNonDisplayClubFunction);
+    expect(wrapper.text()).toContain("タグ編集：");
+  });
+
+  test("何も選択せずにボタンを押下した場合", async () => {
+    // コンポーネントのマウント
+    const wrapper = mount(addNonDisplayClubFunction);
+    // // POSTリクエストの実行
+    await wrapper.find("#addnonDisplayClubBtn").trigger("click");
+    const errorMsg = wrapper.vm.msgForaddnonDisplayClub;
+    console.log(wrapper.vm.msgForaddnonDisplayClub);
+    expect(errorMsg).toBe("サークルを選択してください");
+  });
+
+  test("value:1のラジオボタンを選んでボタンを押下", async () => {
+    // コンポーネントのマウント
+    const wrapper = mount(addNonDisplayClubFunction);
+    // valueが1のラジオボタンを確認
+    const radioInput = wrapper.find(
+      'input[type="radio"][id="nonDisplayclub3"]'
+    );
+    expect(radioInput.wrapperElement._value.id).toEqual("3");
+    // //チェックをして、送信
+    await radioInput.setChecked();
+    await wrapper.find("#addnonDisplayClubBtn").trigger("click");
+    const response = await axios.patch("/api/club/nonDisplayClub", {
+      nondisplayClub: radioInput.wrapperElement._value.id,
+    });
+    // 成功メッセージが表示されることを確認
+    expect(response.data).toEqual({ message: "Success" });
+    // エラーメッセージも表示されていないことを確認
+    expect(wrapper.text()).not.toContain("サークルを選択してください");
+  });
+});

--- a/test/ownerPage/changeAdvent.test.js
+++ b/test/ownerPage/changeAdvent.test.js
@@ -1,0 +1,30 @@
+import registerAdvent from "../../components/ownerPage/registerAdvent.vue"; // テスト対象のページ
+import { mount } from "@vue/test-utils";
+import axios from "axios";
+
+describe("アドベントカレンダーを変更するテスト", () => {
+  test("ページが初期の状態でマウントされているか確認", async () => {
+    const wrapper = mount(registerAdvent);
+    expect(wrapper.text()).toContain("バナー表示：");
+
+    expect(wrapper.vm.showAdvent).toBe(1);
+    expect(wrapper.vm.choseAdvent).toBe(1);
+  });
+
+  test("表示するバナーを変更した時、値を変える", async () => {
+    const wrapper = mount(registerAdvent);
+
+    const newValue = wrapper.find("#displayValue");
+    await newValue.setValue("3");
+    await wrapper.find(".btn").trigger("click");
+
+    const mockResponse = { data: { message: "Success" } };
+    jest.spyOn(axios, "post").mockResolvedValue(mockResponse);
+    const response = await axios.post("/api/advent/chooseAdvent", {
+      newAdventValue: "3",
+    });
+
+    // 成功メッセージが表示されることを確認
+    expect(response.data).toEqual({ message: "Success" });
+  });
+});

--- a/test/ownerPage/deleteClub.test.js
+++ b/test/ownerPage/deleteClub.test.js
@@ -38,12 +38,12 @@ describe("addDisplayClubFunction", () => {
     // コンポーネントのマウント
     const wrapper = mount(deleteClubFunction);
 
-    // 1を投げた場合、成功
+    // 1を投げた場合、成功→できていない修正要
     // const deleteReqId = wrapper.vm.addDisplayClub;
     // deleteReqId.value = "1";
-    // console.log(deleteReqId);
 
     // const deleteClubId = addDisplayClub.value.id;
+
     // const response1 = await axios.delete(
     //   `/api/club/delete?clubid=${deleteClubId}`
     // );

--- a/test/ownerPage/deleteClub.test.js
+++ b/test/ownerPage/deleteClub.test.js
@@ -1,0 +1,57 @@
+import deleteClubFunction from "../../components/ownerPage/ClubFunction.vue"; // テスト対象のページ
+import { mount } from "@vue/test-utils";
+import axios from "axios";
+import { rest } from "msw";
+import { setupServer } from "msw/node";
+
+// MSWでサーバーのモック作成;
+const server = setupServer(
+  rest.delete("/api/club/delete", (req, res, ctx) => {
+    const query = req.url.searchParams.get("clubid");
+    if (query === "1") {
+      return res(ctx.json({ message: "Success" }));
+    } else if (query === "10") {
+      return res(ctx.json({ message: "Failed" }));
+    }
+  })
+);
+beforeAll(() => {
+  server.listen();
+});
+beforeEach(() => {
+  jest.restoreAllMocks();
+});
+afterEach(() => {
+  server.resetHandlers();
+});
+afterAll(() => {
+  server.close();
+});
+
+describe("addDisplayClubFunction", () => {
+  test("ページがマウントできているか確認", async () => {
+    const wrapper = mount(deleteClubFunction);
+    expect(wrapper.text()).toContain("タグ編集：");
+  });
+
+  test("削除リクエストを送信", async () => {
+    // コンポーネントのマウント
+    const wrapper = mount(deleteClubFunction);
+
+    // 1を投げた場合、成功
+    // const deleteReqId = wrapper.vm.addDisplayClub;
+    // deleteReqId.value = "1";
+    // console.log(deleteReqId);
+
+    // const deleteClubId = addDisplayClub.value.id;
+    // const response1 = await axios.delete(
+    //   `/api/club/delete?clubid=${deleteClubId}`
+    // );
+    const response1 = await axios.delete("/api/club/delete?clubid=1");
+    expect(response1.data).toEqual({ message: "Success" });
+
+    // 10を投げた場合、失敗
+    const response10 = await axios.delete("/api/club/delete?clubid=10");
+    expect(response10.data).toEqual({ message: "Failed" });
+  });
+});

--- a/test/ownerPage/ownerAuth.test.js
+++ b/test/ownerPage/ownerAuth.test.js
@@ -1,8 +1,8 @@
-import submitOwner from "../components/ownerPage/SubmitOwner.vue"; // テスト対象のページ
+import submitOwner from "../../components/ownerPage/SubmitOwner.vue"; // テスト対象のページ
 import { mount } from "@vue/test-utils";
 import axios from "axios";
 
-describe("ownerPage", () => {
+describe("管理者権限付与/削除のテスト", () => {
   test("ページが初期の状態でマウントされているか確認", async () => {
     const wrapper = mount(submitOwner);
 


### PR DESCRIPTION
## Issue のリンク

-

## やったこと(What,How)

- 管理者ページのテスト
  - 管理者ページのコードをコンポーネントに分割
    - サークル部分のHTML
    - アドベントのHTML
    - 管理者権限付与のHTML
  - 関数ごとにテストファイルを作成、実施

## やらないこと

- [test/ownerPage/deleteClub.test.js]でやりたいテストがまだできていないので、コメントアウト部分を残しています

## できるようになること（ユーザ目線）(Why,Who)

-

## できなくなること（ユーザ目線）

-

## 動作確認

-

## タスク

-

## エラー表示内容

-

## その他

-
